### PR TITLE
Range fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-string",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-string",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Encode and decode web-safe base64 consent information with the IAB EU's GDPR Transparency and Consent Framework",
   "homepage": "https://github.com/InteractiveAdvertisingBureau/Consent-String-SDK-JS",
   "keywords": [

--- a/src/consent-string.js
+++ b/src/consent-string.js
@@ -153,7 +153,19 @@ class ConsentString {
       throw new Error('ConsentString - The provided vendor list does not respect the schema from the IAB EU’s GDPR Consent and Transparency Framework');
     }
 
-    this.vendorList = vendorList;
+    // Cloning the GVL
+    // It's important as we might transform it and don't want to modify objects that we do not own
+    this.vendorList = {
+      vendorListVersion: vendorList.vendorListVersion,
+      lastUpdated: vendorList.lastUpdated,
+      purposes: vendorList.purposes,
+      features: vendorList.features,
+
+      // Clone the list and sort the vendors by ID (it breaks our range generation algorithm if they are not sorted)
+      vendors: vendorList.vendors
+        .slice(0)
+        .sort((firstVendor, secondVendor) => (firstVendor.id < secondVendor.id ? -1 : 1)),
+    };
     this.vendorListVersion = vendorList.vendorListVersion;
   }
 

--- a/test/consent-string.test.js
+++ b/test/consent-string.test.js
@@ -14,19 +14,12 @@ describe('ConsentString', function () {
     consentScreen: 3,
     consentLanguage: 'en',
     vendorListVersion: 1,
-    maxVendorId: vendorList.vendors[vendorList.vendors.length - 1].id,
+    maxVendorId: Math.max(...vendorList.vendors.map(vendor => vendor.id)),
     created: aDate,
     lastUpdated: aDate,
     allowedPurposeIds: [1, 2],
     allowedVendorIds: [1, 2, 4],
   };
-
-  it('gives the same result when decoding then encoding data with no changes', function () {
-    const encodedConsentString = 'BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA';
-    const consentString = new ConsentString(encodedConsentString);
-    consentString.setGlobalVendorList(vendorList);
-    expect(consentString.getConsentString(false)).to.equal(encodedConsentString);
-  });
 
   it('gives the same result when encoding then decoding data', function () {
     const consentString = new ConsentString();
@@ -104,6 +97,24 @@ describe('ConsentString', function () {
       })).to.be.undefined;
 
       expect(consent.vendorListVersion).to.equal(1);
+    });
+
+    it('sorts the vendor list by ID', function () {
+      const consent = new ConsentString();
+
+      consent.setGlobalVendorList({
+        vendorListVersion: 1,
+        purposes: [],
+        vendors: [
+          { id: 2 },
+          { id: 1 },
+        ],
+      });
+
+      expect(consent.vendorList.vendors).to.deep.equal([
+        { id: 1 },
+        { id: 2 },
+      ]);
     });
   });
 });

--- a/test/decode.test.js
+++ b/test/decode.test.js
@@ -1,7 +1,5 @@
 const { expect } = require('chai');
 
-const vendorList = require('./vendors.json');
-
 const { decodeConsentString } = require('../src/decode');
 
 describe('decode', function () {
@@ -17,7 +15,7 @@ describe('decode', function () {
       consentScreen: 3,
       consentLanguage: 'en',
       vendorListVersion: 1,
-      maxVendorId: vendorList.vendors[vendorList.vendors.length - 1].id,
+      maxVendorId: 1171,
       created: aDate,
       lastUpdated: aDate,
       allowedPurposeIds: [1, 2],

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -2,7 +2,71 @@ const { expect } = require('chai');
 
 const vendorList = require('./vendors.json');
 
-const { encodeConsentString } = require('../src/encode');
+const {
+  convertVendorsToRanges,
+  encodeConsentString,
+} = require('../src/encode');
+
+describe('convertVendorsToRanges', function () {
+  it('converts a list of vendors to a full range', function () {
+    expect(convertVendorsToRanges(
+      [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+      ],
+      [1, 2, 3, 4, 5],
+    )).to.deep.equal([
+      { isRange: true, startVendorId: 1, endVendorId: 5 },
+    ]);
+  });
+
+  it('converts a list of vendors to a multiple ranges as needed', function () {
+    expect(convertVendorsToRanges(
+      [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+        { id: 5 },
+      ],
+      [1, 2, 3, 5],
+    )).to.deep.equal([
+      { isRange: true, startVendorId: 1, endVendorId: 3 },
+      { isRange: false, startVendorId: 5, endVendorId: undefined },
+    ]);
+  });
+
+  it('ignores missing vendors when creating ranges', function () {
+    expect(convertVendorsToRanges(
+      [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 7 },
+      ],
+      [1, 2, 3, 7],
+    )).to.deep.equal([
+      { isRange: true, startVendorId: 1, endVendorId: 3 },
+      { isRange: false, startVendorId: 7, endVendorId: undefined },
+    ]);
+
+    expect(convertVendorsToRanges(
+      [
+        { id: 1 },
+        { id: 3 },
+        { id: 7 },
+      ],
+      [1, 3, 7],
+    )).to.deep.equal([
+      { isRange: false, startVendorId: 1, endVendorId: undefined },
+      { isRange: false, startVendorId: 3, endVendorId: undefined },
+      { isRange: false, startVendorId: 7, endVendorId: undefined },
+    ]);
+  });
+});
 
 describe('encode', function () {
   const aDate = new Date('2018-07-15 PDT');
@@ -23,6 +87,6 @@ describe('encode', function () {
     };
 
     const encodedString = encodeConsentString(consentData);
-    expect(encodedString).to.equal('BOQ7WlgOQ7WlgABACDENABwAAABJOACgACAAQABA');
+    expect(encodedString).to.equal('BOQ7WlgOQ7WlgABACDENAOwAAAAHCADAACAAQAAQ');
   });
 });

--- a/test/vendors.json
+++ b/test/vendors.json
@@ -1,4700 +1,1232 @@
 {
-  "vendorListVersion": 1,
-  "origin": "http://ib.adnxs.com/vendors.json",
-  "purposes": [
-	{
-	  "id": 1,
-	  "name": "Accessing a Device or Browser"
-	},
-	{
-	  "id": 2,
-	  "name": "Advertising Personalisation"
-	},
-	{
-	  "id": 3,
-	  "name": "Analytics"
-	},
-	{
-	  "id": 4,
-	  "name": "Content Personalisation"
-	}
-  ],
-  "vendors": [
-	{
-	  "id": 1,
-	  "name": "1000mercis S.A."
-	},
-	{
-	  "id": 2,
-	  "name": "12 Digit Media Inc."
-	},
-	{
-	  "id": 3,
-	  "name": "123 Greetings Inc."
-	},
-	{
-	  "id": 4,
-	  "name": "1Advertising Global GmbH"
-	},
-	{
-	  "id": 5,
-	  "name": "1KXUN"
-	},
-	{
-	  "id": 6,
-	  "name": "21 Productions"
-	},
-	{
-	  "id": 7,
-	  "name": "24-Ads Gmbh"
-	},
-	{
-	  "id": 8,
-	  "name": "254A.Com"
-	},
-	{
-	  "id": 9,
-	  "name": "2KDirect Inc."
-	},
-	{
-	  "id": 10,
-	  "name": "2Y Media Sas (Adserverpub)"
-	},
-	{
-	  "id": 11,
-	  "name": "33Across, Inc"
-	},
-	{
-	  "id": 12,
-	  "name": "3Lift.Com"
-	},
-	{
-	  "id": 13,
-	  "name": "4Cite Marketing"
-	},
-	{
-	  "id": 14,
-	  "name": "4Info Inc"
-	},
-	{
-	  "id": 15,
-	  "name": "4th Screen Advertising Limited"
-	},
-	{
-	  "id": 16,
-	  "name": "7Hops.com, Inc."
-	},
-	{
-	  "id": 17,
-	  "name": "8 Inc."
-	},
-	{
-	  "id": 18,
-	  "name": "A Sharp Inc."
-	},
-	{
-	  "id": 19,
-	  "name": "A.Mob"
-	},
-	{
-	  "id": 20,
-	  "name": "A3Cloud.Net"
-	},
-	{
-	  "id": 21,
-	  "name": "Aarki, Inc."
-	},
-	{
-	  "id": 22,
-	  "name": "Aarth.Com"
-	},
-	{
-	  "id": 23,
-	  "name": "Abilicom Gmbh"
-	},
-	{
-	  "id": 24,
-	  "name": "AccentHealth, LLC"
-	},
-	{
-	  "id": 25,
-	  "name": "Accenture Global Services Limited"
-	},
-	{
-	  "id": 26,
-	  "name": "Accmgr.Com"
-	},
-	{
-	  "id": 27,
-	  "name": "Accordant Media, LLC"
-	},
-	{
-	  "id": 28,
-	  "name": "Accuen Inc."
-	},
-	{
-	  "id": 29,
-	  "name": "Action Exchange, Inc."
-	},
-	{
-	  "id": 30,
-	  "name": "Active Agent AG"
-	},
-	{
-	  "id": 31,
-	  "name": "Acuity Ads, Inc."
-	},
-	{
-	  "id": 32,
-	  "name": "Ad Pepper Media International N.V."
-	},
-	{
-	  "id": 33,
-	  "name": "Ad-Score.Com"
-	},
-	{
-	  "id": 34,
-	  "name": "Ad-Srv.Net"
-	},
-	{
-	  "id": 35,
-	  "name": "Adacado, Inc."
-	},
-	{
-	  "id": 36,
-	  "name": "Adadvisor"
-	},
-	{
-	  "id": 37,
-	  "name": "Adadyn Technologies Private Limited"
-	},
-	{
-	  "id": 38,
-	  "name": "Adap.TV Video"
-	},
-	{
-	  "id": 39,
-	  "name": "Adara Media, Inc."
-	},
-	{
-	  "id": 40,
-	  "name": "Adblade"
-	},
-	{
-	  "id": 41,
-	  "name": "Adbox Digital Limited"
-	},
-	{
-	  "id": 42,
-	  "name": "Adbrain Ltd."
-	},
-	{
-	  "id": 43,
-	  "name": "AdBrite Inc."
-	},
-	{
-	  "id": 44,
-	  "name": "Adcash"
-	},
-	{
-	  "id": 45,
-	  "name": "Adclear Gmbh"
-	},
-	{
-	  "id": 46,
-	  "name": "Adconion GmbH"
-	},
-	{
-	  "id": 47,
-	  "name": "Adcrowd Bv"
-	},
-	{
-	  "id": 48,
-	  "name": "AdDaptive Intelligence, Inc."
-	},
-	{
-	  "id": 49,
-	  "name": "Addictive Tech Corp."
-	},
-	{
-	  "id": 50,
-	  "name": "Addition Plus Limited"
-	},
-	{
-	  "id": 51,
-	  "name": "Addkt, LLC"
-	},
-	{
-	  "id": 52,
-	  "name": "Addmilk.Nl"
-	},
-	{
-	  "id": 53,
-	  "name": "Addthis, Inc."
-	},
-	{
-	  "id": 54,
-	  "name": "Adelement Media Solutions Pvt. Ltd"
-	},
-	{
-	  "id": 55,
-	  "name": "AdElement, Inc."
-	},
-	{
-	  "id": 56,
-	  "name": "Adello Group AG"
-	},
-	{
-	  "id": 57,
-	  "name": "Adelphic, Inc."
-	},
-	{
-	  "id": 58,
-	  "name": "AdForm A/S"
-	},
-	{
-	  "id": 59,
-	  "name": "Adgear Technologies Inc."
-	},
-	{
-	  "id": 60,
-	  "name": "Adinti BV"
-	},
-	{
-	  "id": 61,
-	  "name": "Adiquity Pte Ltd."
-	},
-	{
-	  "id": 62,
-	  "name": "Adition"
-	},
-	{
-	  "id": 63,
-	  "name": "AdKernel LLC"
-	},
-	{
-	  "id": 64,
-	  "name": "Adledge"
-	},
-	{
-	  "id": 65,
-	  "name": "Adloox SAS"
-	},
-	{
-	  "id": 66,
-	  "name": "Adlucent Llc"
-	},
-	{
-	  "id": 67,
-	  "name": "AdMaxim LLC"
-	},
-	{
-	  "id": 68,
-	  "name": "Admeta Ab"
-	},
-	{
-	  "id": 69,
-	  "name": "AdMetrics Media Ltd"
-	},
-	{
-	  "id": 70,
-	  "name": "Admixer"
-	},
-	{
-	  "id": 71,
-	  "name": "Admized Ag"
-	},
-	{
-	  "id": 72,
-	  "name": "AdMotion"
-	},
-	{
-	  "id": 73,
-	  "name": "Adnomia Dijital Pazarlama ve Medya A.?."
-	},
-	{
-	  "id": 74,
-	  "name": "Adobe Systems Inc."
-	},
-	{
-	  "id": 75,
-	  "name": "Adoftheyear.Com"
-	},
-	{
-	  "id": 76,
-	  "name": "Adomik, Inc"
-	},
-	{
-	  "id": 77,
-	  "name": "Adorika Media Ltd."
-	},
-	{
-	  "id": 78,
-	  "name": "Adperium B.V."
-	},
-	{
-	  "id": 79,
-	  "name": "AdQuiver Media SL"
-	},
-	{
-	  "id": 80,
-	  "name": "Adrime"
-	},
-	{
-	  "id": 81,
-	  "name": "Adriver Limited Liability Company"
-	},
-	{
-	  "id": 82,
-	  "name": "Adroll"
-	},
-	{
-	  "id": 83,
-	  "name": "Adscale Gmbh"
-	},
-	{
-	  "id": 84,
-	  "name": "Adscience.Nl"
-	},
-	{
-	  "id": 85,
-	  "name": "Adserving Factory Srl"
-	},
-	{
-	  "id": 86,
-	  "name": "Adsit Media Advertising Ltd. Co."
-	},
-	{
-	  "id": 87,
-	  "name": "Adskom Pte Ltd"
-	},
-	{
-	  "id": 88,
-	  "name": "Adsnative.Com"
-	},
-	{
-	  "id": 89,
-	  "name": "AdSniper LLC"
-	},
-	{
-	  "id": 90,
-	  "name": "Adspeed.Com"
-	},
-	{
-	  "id": 91,
-	  "name": "Adspert Bidmanagement Gmbh"
-	},
-	{
-	  "id": 92,
-	  "name": "Adspirit Gmbh"
-	},
-	{
-	  "id": 93,
-	  "name": "Adsquare GmbH"
-	},
-	{
-	  "id": 94,
-	  "name": "Adssets"
-	},
-	{
-	  "id": 95,
-	  "name": "AdsWizz Inc."
-	},
-	{
-	  "id": 96,
-	  "name": "adTheorent, Inc."
-	},
-	{
-	  "id": 97,
-	  "name": "Adthink Media"
-	},
-	{
-	  "id": 98,
-	  "name": "AdThrive, LLC"
-	},
-	{
-	  "id": 99,
-	  "name": "Adtomation, Inc."
-	},
-	{
-	  "id": 100,
-	  "name": "Adtoox Ab"
-	},
-	{
-	  "id": 101,
-	  "name": "Adtraction Marketing Ab"
-	},
-	{
-	  "id": 102,
-	  "name": "ADTUBE AS"
-	},
-	{
-	  "id": 103,
-	  "name": "AdUX"
-	},
-	{
-	  "id": 104,
-	  "name": "Advance International Media"
-	},
-	{
-	  "id": 105,
-	  "name": "Advanse Llc"
-	},
-	{
-	  "id": 106,
-	  "name": "Adventori SAS"
-	},
-	{
-	  "id": 107,
-	  "name": "Adverline SAS"
-	},
-	{
-	  "id": 108,
-	  "name": "Adverplex Inc."
-	},
-	{
-	  "id": 109,
-	  "name": "Adverserve.Net"
-	},
-	{
-	  "id": 110,
-	  "name": "Advertising.com (AOL)"
-	},
-	{
-	  "id": 111,
-	  "name": "Advertising.net, Inc."
-	},
-	{
-	  "id": 112,
-	  "name": "Advolution"
-	},
-	{
-	  "id": 113,
-	  "name": "AdYouLike S.A."
-	},
-	{
-	  "id": 114,
-	  "name": "Adzuum Ltd."
-	},
-	{
-	  "id": 115,
-	  "name": "Affec.Tv"
-	},
-	{
-	  "id": 116,
-	  "name": "Affilinet Gmbh"
-	},
-	{
-	  "id": 117,
-	  "name": "Affilired, S.L."
-	},
-	{
-	  "id": 118,
-	  "name": "Affility"
-	},
-	{
-	  "id": 119,
-	  "name": "Affiperf Limited"
-	},
-	{
-	  "id": 120,
-	  "name": "Agency X LLC"
-	},
-	{
-	  "id": 121,
-	  "name": "Agl Import"
-	},
-	{
-	  "id": 122,
-	  "name": "aim4media BV"
-	},
-	{
-	  "id": 123,
-	  "name": "Air France"
-	},
-	{
-	  "id": 124,
-	  "name": "airG Worldwide Cooperatie U.A."
-	},
-	{
-	  "id": 125,
-	  "name": "AirPR, Inc."
-	},
-	{
-	  "id": 126,
-	  "name": "Akamai"
-	},
-	{
-	  "id": 127,
-	  "name": "AlephD SaS"
-	},
-	{
-	  "id": 128,
-	  "name": "Alfahosting Gmbh"
-	},
-	{
-	  "id": 129,
-	  "name": "All Day Media, Inc"
-	},
-	{
-	  "id": 130,
-	  "name": "Alma Media Oyj"
-	},
-	{
-	  "id": 131,
-	  "name": "Alter, Rafael"
-	},
-	{
-	  "id": 132,
-	  "name": "Altitude Digital Partners"
-	},
-	{
-	  "id": 133,
-	  "name": "Amazon"
-	},
-	{
-	  "id": 134,
-	  "name": "Amazon CloudFront"
-	},
-	{
-	  "id": 135,
-	  "name": "AMG Advertising Spain SL"
-	},
-	{
-	  "id": 136,
-	  "name": "Amicus Enterprises, Inc."
-	},
-	{
-	  "id": 137,
-	  "name": "Amino Payments Inc."
-	},
-	{
-	  "id": 138,
-	  "name": "Amnet"
-	},
-	{
-	  "id": 139,
-	  "name": "Amobee, Inc"
-	},
-	{
-	  "id": 140,
-	  "name": "Analyticaa P.M. Gmbh"
-	},
-	{
-	  "id": 141,
-	  "name": "Aniview Ltd"
-	},
-	{
-	  "id": 142,
-	  "name": "Answers Corporation"
-	},
-	{
-	  "id": 143,
-	  "name": "AOL"
-	},
-	{
-	  "id": 144,
-	  "name": "Appier Pte. Ltd."
-	},
-	{
-	  "id": 145,
-	  "name": "AppLovin Corp."
-	},
-	{
-	  "id": 146,
-	  "name": "AppNexus"
-	},
-	{
-	  "id": 147,
-	  "name": "Appsflyer"
-	},
-	{
-	  "id": 148,
-	  "name": "Apt-Ebusiness Gmbh"
-	},
-	{
-	  "id": 149,
-	  "name": "Aptroid Technologies Pte Ltd"
-	},
-	{
-	  "id": 150,
-	  "name": "ARAnet Inc."
-	},
-	{
-	  "id": 151,
-	  "name": "Arbor"
-	},
-	{
-	  "id": 152,
-	  "name": "ARC Science Ltd."
-	},
-	{
-	  "id": 153,
-	  "name": "Areyouahuman.Com"
-	},
-	{
-	  "id": 154,
-	  "name": "Armis SAS"
-	},
-	{
-	  "id": 155,
-	  "name": "Arrivalist.Com"
-	},
-	{
-	  "id": 156,
-	  "name": "Ask.fm Europe Limited"
-	},
-	{
-	  "id": 157,
-	  "name": "Audience Partners LLC"
-	},
-	{
-	  "id": 158,
-	  "name": "Audience Square SAS"
-	},
-	{
-	  "id": 159,
-	  "name": "Audiencemanager"
-	},
-	{
-	  "id": 160,
-	  "name": "AudienceScience Inc."
-	},
-	{
-	  "id": 161,
-	  "name": "Augur.Io"
-	},
-	{
-	  "id": 162,
-	  "name": "Auto Trader Ltd."
-	},
-	{
-	  "id": 163,
-	  "name": "Auto1 Marketing Services"
-	},
-	{
-	  "id": 164,
-	  "name": "Automattic, Inc."
-	},
-	{
-	  "id": 165,
-	  "name": "Automotive Exchange Pty Ltd"
-	},
-	{
-	  "id": 166,
-	  "name": "Avazu"
-	},
-	{
-	  "id": 167,
-	  "name": "Aviteo Ltd., Zweigniederlassung Muenchen"
-	},
-	{
-	  "id": 168,
-	  "name": "Avocet Systems Limited"
-	},
-	{
-	  "id": 169,
-	  "name": "Axel Springer"
-	},
-	{
-	  "id": 170,
-	  "name": "Azalead Software SAS"
-	},
-	{
-	  "id": 171,
-	  "name": "Badoo Trading Limited"
-	},
-	{
-	  "id": 172,
-	  "name": "Bannerconnect B.V."
-	},
-	{
-	  "id": 173,
-	  "name": "BannerFlow"
-	},
-	{
-	  "id": 174,
-	  "name": "Batanga, Inc."
-	},
-	{
-	  "id": 175,
-	  "name": "Baur Versand Gmbh & Co Kg"
-	},
-	{
-	  "id": 176,
-	  "name": "Bazaarvoice, Inc."
-	},
-	{
-	  "id": 177,
-	  "name": "Beachfront Media Llc"
-	},
-	{
-	  "id": 178,
-	  "name": "BeesWax.io Corporation"
-	},
-	{
-	  "id": 179,
-	  "name": "Beintoo Spa"
-	},
-	{
-	  "id": 180,
-	  "name": "Belboon Gmbh"
-	},
-	{
-	  "id": 181,
-	  "name": "Bering Media"
-	},
-	{
-	  "id": 182,
-	  "name": "Betgenius Limited"
-	},
-	{
-	  "id": 183,
-	  "name": "Better Banners"
-	},
-	{
-	  "id": 184,
-	  "name": "Between Digital"
-	},
-	{
-	  "id": 185,
-	  "name": "Bidr.Io"
-	},
-	{
-	  "id": 186,
-	  "name": "Bidswitch GmbH"
-	},
-	{
-	  "id": 187,
-	  "name": "Bidtellect, Inc."
-	},
-	{
-	  "id": 188,
-	  "name": "BidTheatre AB"
-	},
-	{
-	  "id": 189,
-	  "name": "Big Mobile Group Pty Ltd"
-	},
-	{
-	  "id": 190,
-	  "name": "Biga Bid Media Ltd"
-	},
-	{
-	  "id": 191,
-	  "name": "Bit.ly"
-	},
-	{
-	  "id": 192,
-	  "name": "Bitdefender Srl"
-	},
-	{
-	  "id": 193,
-	  "name": "Blau.De"
-	},
-	{
-	  "id": 194,
-	  "name": "Blis Media Ltd."
-	},
-	{
-	  "id": 195,
-	  "name": "Blogo.it srl"
-	},
-	{
-	  "id": 196,
-	  "name": "BLOOM Digital Platforms Inc."
-	},
-	{
-	  "id": 197,
-	  "name": "BlueCava Inc."
-	},
-	{
-	  "id": 198,
-	  "name": "BlueKai"
-	},
-	{
-	  "id": 199,
-	  "name": "BMind Sales Maker Company S.L."
-	},
-	{
-	  "id": 200,
-	  "name": "Bohemia Group Pty Ltd"
-	},
-	{
-	  "id": 201,
-	  "name": "Bootstrapcdn.Com"
-	},
-	{
-	  "id": 202,
-	  "name": "Brandsmind"
-	},
-	{
-	  "id": 203,
-	  "name": "BrightRoll, Inc."
-	},
-	{
-	  "id": 204,
-	  "name": "Brille24 Gmbh"
-	},
-	{
-	  "id": 205,
-	  "name": "Builder Homesite, Inc."
-	},
-	{
-	  "id": 206,
-	  "name": "Burst!"
-	},
-	{
-	  "id": 207,
-	  "name": "Business.com Media, Inc."
-	},
-	{
-	  "id": 208,
-	  "name": "C2B S.A."
-	},
-	{
-	  "id": 209,
-	  "name": "C3 Metrics, Inc."
-	},
-	{
-	  "id": 210,
-	  "name": "CAPITAL DATA"
-	},
-	{
-	  "id": 211,
-	  "name": "Capslock Digital Solutions Pvt. Ltd."
-	},
-	{
-	  "id": 212,
-	  "name": "Captify Technologies Ltd"
-	},
-	{
-	  "id": 213,
-	  "name": "Car&Boat Media SAS"
-	},
-	{
-	  "id": 214,
-	  "name": "Cardlytics, Inc."
-	},
-	{
-	  "id": 215,
-	  "name": "Cargurus Inc."
-	},
-	{
-	  "id": 216,
-	  "name": "Carre Blanc Distribution"
-	},
-	{
-	  "id": 217,
-	  "name": "Casele Media"
-	},
-	{
-	  "id": 218,
-	  "name": "Catimini Sas"
-	},
-	{
-	  "id": 219,
-	  "name": "CBS Interactive Inc."
-	},
-	{
-	  "id": 220,
-	  "name": "CBT Sports, LLC"
-	},
-	{
-	  "id": 221,
-	  "name": "CDiscount SA"
-	},
-	{
-	  "id": 222,
-	  "name": "Cdk Global, Llc."
-	},
-	{
-	  "id": 223,
-	  "name": "Cdnwebcloud.Com"
-	},
-	{
-	  "id": 224,
-	  "name": "Cedato Technologies Ltd"
-	},
-	{
-	  "id": 225,
-	  "name": "Celtra Inc."
-	},
-	{
-	  "id": 226,
-	  "name": "Centro Media Inc."
-	},
-	{
-	  "id": 227,
-	  "name": "Centro.Net"
-	},
-	{
-	  "id": 228,
-	  "name": "Chalk Digital, Inc."
-	},
-	{
-	  "id": 229,
-	  "name": "Chitika, Inc."
-	},
-	{
-	  "id": 230,
-	  "name": "ChoiceStream, Inc."
-	},
-	{
-	  "id": 231,
-	  "name": "Cint Ab"
-	},
-	{
-	  "id": 232,
-	  "name": "CIX Inc"
-	},
-	{
-	  "id": 233,
-	  "name": "Claranet"
-	},
-	{
-	  "id": 234,
-	  "name": "ClearPier, Inc"
-	},
-	{
-	  "id": 235,
-	  "name": "Clearstream.Tv, Inc"
-	},
-	{
-	  "id": 236,
-	  "name": "Click Performance GmbH"
-	},
-	{
-	  "id": 237,
-	  "name": "Clickagy.Com"
-	},
-	{
-	  "id": 238,
-	  "name": "ClickDistrict B.V."
-	},
-	{
-	  "id": 239,
-	  "name": "Clinch.Co"
-	},
-	{
-	  "id": 240,
-	  "name": "Clique Media FZ LLC"
-	},
-	{
-	  "id": 241,
-	  "name": "Cloud Technologies S.A."
-	},
-	{
-	  "id": 242,
-	  "name": "Cloudflate"
-	},
-	{
-	  "id": 243,
-	  "name": "Cloudinary Ltd."
-	},
-	{
-	  "id": 244,
-	  "name": "CMI Marketing Inc"
-	},
-	{
-	  "id": 245,
-	  "name": "Cocomore Ag"
-	},
-	{
-	  "id": 246,
-	  "name": "CodeWise Sp. z. o. o. Sp. K."
-	},
-	{
-	  "id": 247,
-	  "name": "Coed Media Group LLC"
-	},
-	{
-	  "id": 248,
-	  "name": "Coffee Can Media, Inc"
-	},
-	{
-	  "id": 249,
-	  "name": "Colibri SAS"
-	},
-	{
-	  "id": 250,
-	  "name": "Collective Inc."
-	},
-	{
-	  "id": 251,
-	  "name": "Collective Roll Inc."
-	},
-	{
-	  "id": 252,
-	  "name": "Collserve.Com"
-	},
-	{
-	  "id": 253,
-	  "name": "Colt Technology Services Gmbh"
-	},
-	{
-	  "id": 254,
-	  "name": "Compea Gmbh & Co. Kg"
-	},
-	{
-	  "id": 255,
-	  "name": "comScore Inc."
-	},
-	{
-	  "id": 256,
-	  "name": "conceptCPH ApS"
-	},
-	{
-	  "id": 257,
-	  "name": "Connect Digital Hizmetleri Ltd Sti."
-	},
-	{
-	  "id": 258,
-	  "name": "Connexity, Inc."
-	},
-	{
-	  "id": 259,
-	  "name": "Constant Contact, Inc."
-	},
-	{
-	  "id": 260,
-	  "name": "Contact Impact GmbH"
-	},
-	{
-	  "id": 261,
-	  "name": "Contech, Llc"
-	},
-	{
-	  "id": 262,
-	  "name": "ContextWeb"
-	},
-	{
-	  "id": 263,
-	  "name": "Contobox"
-	},
-	{
-	  "id": 264,
-	  "name": "Conversant Ad Server"
-	},
-	{
-	  "id": 265,
-	  "name": "Conversant, LLC"
-	},
-	{
-	  "id": 266,
-	  "name": "Conversion Logic"
-	},
-	{
-	  "id": 267,
-	  "name": "ConvertMedia Ltd."
-	},
-	{
-	  "id": 268,
-	  "name": "Convertro, Inc"
-	},
-	{
-	  "id": 269,
-	  "name": "Conyak"
-	},
-	{
-	  "id": 270,
-	  "name": "Coolblue"
-	},
-	{
-	  "id": 271,
-	  "name": "CoolMath.com, LLC"
-	},
-	{
-	  "id": 272,
-	  "name": "Couller Ltd"
-	},
-	{
-	  "id": 273,
-	  "name": "Cox Digital Solutions"
-	},
-	{
-	  "id": 274,
-	  "name": "CPMonly"
-	},
-	{
-	  "id": 275,
-	  "name": "Crazy Egg, Inc."
-	},
-	{
-	  "id": 276,
-	  "name": "Cree8 B.V."
-	},
-	{
-	  "id": 277,
-	  "name": "Crimson Tangerine Ltd"
-	},
-	{
-	  "id": 278,
-	  "name": "Criteo SA"
-	},
-	{
-	  "id": 279,
-	  "name": "Csc Corporate Domains, Inc."
-	},
-	{
-	  "id": 280,
-	  "name": "Ctnsnet.Com"
-	},
-	{
-	  "id": 281,
-	  "name": "Curse Inc."
-	},
-	{
-	  "id": 282,
-	  "name": "D-O-M Deutsche Online Medien Gmbh"
-	},
-	{
-	  "id": 283,
-	  "name": "D.A.Consortium Inc. (EffectiveOne)"
-	},
-	{
-	  "id": 284,
-	  "name": "d3media AG"
-	},
-	{
-	  "id": 285,
-	  "name": "D60 As"
-	},
-	{
-	  "id": 286,
-	  "name": "Daftcode Sp. z o.o."
-	},
-	{
-	  "id": 287,
-	  "name": "Databerries SA"
-	},
-	{
-	  "id": 288,
-	  "name": "Datalicious Pty Ltd"
-	},
-	{
-	  "id": 289,
-	  "name": "Datalogix Inc."
-	},
-	{
-	  "id": 290,
-	  "name": "DataSphere Technologies, Inc."
-	},
-	{
-	  "id": 291,
-	  "name": "Datawrkz Pte Ltd."
-	},
-	{
-	  "id": 292,
-	  "name": "DataXu Inc."
-	},
-	{
-	  "id": 293,
-	  "name": "Datonics, Llc"
-	},
-	{
-	  "id": 294,
-	  "name": "Dc Storm Ltd."
-	},
-	{
-	  "id": 295,
-	  "name": "De Persgroep Publishing NV"
-	},
-	{
-	  "id": 296,
-	  "name": "Dealer Dot Com Inc."
-	},
-	{
-	  "id": 297,
-	  "name": "Dealer Dot Com, Inc."
-	},
-	{
-	  "id": 298,
-	  "name": "DealPly Technologies Ltd."
-	},
-	{
-	  "id": 299,
-	  "name": "Deep Forest Media"
-	},
-	{
-	  "id": 300,
-	  "name": "Defy Media LLC"
-	},
-	{
-	  "id": 301,
-	  "name": "Deindesign Gmbh"
-	},
-	{
-	  "id": 302,
-	  "name": "Deliverimp.Com"
-	},
-	{
-	  "id": 303,
-	  "name": "Delivery Media, S.L."
-	},
-	{
-	  "id": 304,
-	  "name": "Delta Projects AB"
-	},
-	{
-	  "id": 305,
-	  "name": "Demandbase Inc"
-	},
-	{
-	  "id": 306,
-	  "name": "Democracy Works Inc."
-	},
-	{
-	  "id": 307,
-	  "name": "Departapp"
-	},
-	{
-	  "id": 308,
-	  "name": "Deseret Digital Media Inc."
-	},
-	{
-	  "id": 309,
-	  "name": "Deutsche Telekom Ag"
-	},
-	{
-	  "id": 310,
-	  "name": "DeviantArt Inc"
-	},
-	{
-	  "id": 311,
-	  "name": "Digilant Inc."
-	},
-	{
-	  "id": 312,
-	  "name": "Digital Advertising and Engagement S.L"
-	},
-	{
-	  "id": 313,
-	  "name": "Digital Leopard Inc"
-	},
-	{
-	  "id": 314,
-	  "name": "Digital Media Shopper"
-	},
-	{
-	  "id": 315,
-	  "name": "Digital Remedy"
-	},
-	{
-	  "id": 316,
-	  "name": "Digital To Store (Dts)"
-	},
-	{
-	  "id": 317,
-	  "name": "Digital To Store Limited"
-	},
-	{
-	  "id": 318,
-	  "name": "Digital Window Ltd"
-	},
-	{
-	  "id": 319,
-	  "name": "Digitize New Media Ltd."
-	},
-	{
-	  "id": 320,
-	  "name": "Ding Media Ltd."
-	},
-	{
-	  "id": 321,
-	  "name": "Disney Enterprises, Inc."
-	},
-	{
-	  "id": 322,
-	  "name": "Distribeo"
-	},
-	{
-	  "id": 323,
-	  "name": "District M Inc."
-	},
-	{
-	  "id": 324,
-	  "name": "Districtm.Ca"
-	},
-	{
-	  "id": 325,
-	  "name": "Dmpxs.Com"
-	},
-	{
-	  "id": 326,
-	  "name": "Dmwd Gmbh"
-	},
-	{
-	  "id": 327,
-	  "name": "Dnstination Inc."
-	},
-	{
-	  "id": 328,
-	  "name": "Dotomi"
-	},
-	{
-	  "id": 329,
-	  "name": "Doubleverify Inc."
-	},
-	{
-	  "id": 330,
-	  "name": "Dow Jones & Company Inc"
-	},
-	{
-	  "id": 331,
-	  "name": "DraftKings, Inc."
-	},
-	{
-	  "id": 332,
-	  "name": "Drawbridge, Inc."
-	},
-	{
-	  "id": 333,
-	  "name": "Dropbox, Inc."
-	},
-	{
-	  "id": 334,
-	  "name": "Drugsite Trust"
-	},
-	{
-	  "id": 335,
-	  "name": "Dtzads.Com"
-	},
-	{
-	  "id": 336,
-	  "name": "Dvtps.Com"
-	},
-	{
-	  "id": 337,
-	  "name": "Dynadmic"
-	},
-	{
-	  "id": 338,
-	  "name": "Dynamic 1001 Gmbh"
-	},
-	{
-	  "id": 339,
-	  "name": "Dynamic Logic"
-	},
-	{
-	  "id": 340,
-	  "name": "E-Webtrack.Net"
-	},
-	{
-	  "id": 341,
-	  "name": "Eacdn.Com"
-	},
-	{
-	  "id": 342,
-	  "name": "Easy Marketing Gmbh"
-	},
-	{
-	  "id": 343,
-	  "name": "eBay Inc."
-	},
-	{
-	  "id": 344,
-	  "name": "Ebuilders"
-	},
-	{
-	  "id": 345,
-	  "name": "Ebuzzing"
-	},
-	{
-	  "id": 346,
-	  "name": "ECHTE LIEBE - Agentur f_r digitale Kommunikation UG"
-	},
-	{
-	  "id": 347,
-	  "name": "Education.com Holdings, Inc."
-	},
-	{
-	  "id": 348,
-	  "name": "Eficiens"
-	},
-	{
-	  "id": 349,
-	  "name": "El Toro, LLC"
-	},
-	{
-	  "id": 350,
-	  "name": "Elite Daily, Inc."
-	},
-	{
-	  "id": 351,
-	  "name": "Emediate"
-	},
-	{
-	  "id": 352,
-	  "name": "Emego GmbH"
-	},
-	{
-	  "id": 353,
-	  "name": "Emerse Sverige AB"
-	},
-	{
-	  "id": 354,
-	  "name": "Emetriq GmbH"
-	},
-	{
-	  "id": 355,
-	  "name": "EMX Digital LLC"
-	},
-	{
-	  "id": 356,
-	  "name": "Enbrite"
-	},
-	{
-	  "id": 357,
-	  "name": "engage:BDR Inc."
-	},
-	{
-	  "id": 358,
-	  "name": "Engageclick Inc"
-	},
-	{
-	  "id": 359,
-	  "name": "EQ Advertising Group, Inc."
-	},
-	{
-	  "id": 360,
-	  "name": "Ermisvc.Com"
-	},
-	{
-	  "id": 361,
-	  "name": "Erne.Co"
-	},
-	{
-	  "id": 362,
-	  "name": "Esc Interactive Gmbh"
-	},
-	{
-	  "id": 363,
-	  "name": "Esearchvision.Com"
-	},
-	{
-	  "id": 364,
-	  "name": "eSell Solutions Ltd."
-	},
-	{
-	  "id": 365,
-	  "name": "Esprit Retail B.V. Und Co. Kg"
-	},
-	{
-	  "id": 366,
-	  "name": "Essens.no AS"
-	},
-	{
-	  "id": 367,
-	  "name": "EST Digital Ltd"
-	},
-	{
-	  "id": 368,
-	  "name": "Eulerian Technologies"
-	},
-	{
-	  "id": 369,
-	  "name": "Eurodns Sa"
-	},
-	{
-	  "id": 370,
-	  "name": "EverQuote, Inc."
-	},
-	{
-	  "id": 371,
-	  "name": "Everyday Feminism, LLC"
-	},
-	{
-	  "id": 372,
-	  "name": "Everyscreen Media"
-	},
-	{
-	  "id": 373,
-	  "name": "Evolve Media, LLC"
-	},
-	{
-	  "id": 374,
-	  "name": "Ewe Tel Gmbh"
-	},
-	{
-	  "id": 375,
-	  "name": "eXelate Media Ltd."
-	},
-	{
-	  "id": 376,
-	  "name": "Expedia, Inc."
-	},
-	{
-	  "id": 377,
-	  "name": "Explido Webmarketing Gmbh & Co. Kg"
-	},
-	{
-	  "id": 378,
-	  "name": "Exponential Interactive, Inc."
-	},
-	{
-	  "id": 379,
-	  "name": "Exponential.Com"
-	},
-	{
-	  "id": 380,
-	  "name": "Express Newspapers"
-	},
-	{
-	  "id": 381,
-	  "name": "Extendtv, Inc."
-	},
-	{
-	  "id": 382,
-	  "name": "Extreme Ventures, LLC"
-	},
-	{
-	  "id": 383,
-	  "name": "Eyeota Limited"
-	},
-	{
-	  "id": 384,
-	  "name": "eyeReturn Marketing Inc."
-	},
-	{
-	  "id": 385,
-	  "name": "Eyeview, Inc."
-	},
-	{
-	  "id": 386,
-	  "name": "Ezakus SA"
-	},
-	{
-	  "id": 387,
-	  "name": "Facebook, Inc."
-	},
-	{
-	  "id": 388,
-	  "name": "Factual Inc."
-	},
-	{
-	  "id": 389,
-	  "name": "Fairfax Digital Australia and New Zealand Pty Ltd"
-	},
-	{
-	  "id": 390,
-	  "name": "Falk Multichannel Gmbh"
-	},
-	{
-	  "id": 391,
-	  "name": "Falk Technologies GmbH"
-	},
-	{
-	  "id": 392,
-	  "name": "Fbinhouse.Se"
-	},
-	{
-	  "id": 393,
-	  "name": "Feature Forward Ltd."
-	},
-	{
-	  "id": 394,
-	  "name": "Federated Sample"
-	},
-	{
-	  "id": 395,
-	  "name": "Figaromedias"
-	},
-	{
-	  "id": 396,
-	  "name": "Financeads Gmbh Co. Kg"
-	},
-	{
-	  "id": 397,
-	  "name": "Firstchoice.Co.Uk"
-	},
-	{
-	  "id": 398,
-	  "name": "Firstlead Gmbh"
-	},
-	{
-	  "id": 399,
-	  "name": "Firststars Gmbh"
-	},
-	{
-	  "id": 400,
-	  "name": "Fjord Technologies"
-	},
-	{
-	  "id": 401,
-	  "name": "Flashtalking"
-	},
-	{
-	  "id": 402,
-	  "name": "Flipp Corporation"
-	},
-	{
-	  "id": 403,
-	  "name": "Fluct, Inc"
-	},
-	{
-	  "id": 404,
-	  "name": "Flxone"
-	},
-	{
-	  "id": 405,
-	  "name": "Fnac.Com"
-	},
-	{
-	  "id": 406,
-	  "name": "Fonts.Net"
-	},
-	{
-	  "id": 407,
-	  "name": "Forensiq, LLC"
-	},
-	{
-	  "id": 408,
-	  "name": "Fprnt.Com"
-	},
-	{
-	  "id": 409,
-	  "name": "Francoise Saget"
-	},
-	{
-	  "id": 410,
-	  "name": "FreakOut Inc."
-	},
-	{
-	  "id": 411,
-	  "name": "Free Stream Media Corp."
-	},
-	{
-	  "id": 412,
-	  "name": "Freedom Financial Network Inc."
-	},
-	{
-	  "id": 413,
-	  "name": "FreeMedia Inc."
-	},
-	{
-	  "id": 414,
-	  "name": "Frequence, Inc."
-	},
-	{
-	  "id": 415,
-	  "name": "Fuel451, Inc."
-	},
-	{
-	  "id": 416,
-	  "name": "Fusion Media Limited"
-	},
-	{
-	  "id": 417,
-	  "name": "Fxdepo.Com"
-	},
-	{
-	  "id": 418,
-	  "name": "Gamned SAS"
-	},
-	{
-	  "id": 419,
-	  "name": "Gateway Media LLC"
-	},
-	{
-	  "id": 420,
-	  "name": "Gemius"
-	},
-	{
-	  "id": 421,
-	  "name": "Gemius Adocean Ltd"
-	},
-	{
-	  "id": 422,
-	  "name": "Geniee, Inc."
-	},
-	{
-	  "id": 423,
-	  "name": "Geologic Inc"
-	},
-	{
-	  "id": 424,
-	  "name": "GetIntent USA Inc."
-	},
-	{
-	  "id": 425,
-	  "name": "Getsentry Llc"
-	},
-	{
-	  "id": 426,
-	  "name": "Gfk Nurago Gmbh"
-	},
-	{
-	  "id": 427,
-	  "name": "Ghostery, Inc."
-	},
-	{
-	  "id": 428,
-	  "name": "Giant Media"
-	},
-	{
-	  "id": 429,
-	  "name": "Glassdoor, Inc."
-	},
-	{
-	  "id": 430,
-	  "name": "GNM Australia PTY LTD"
-	},
-	{
-	  "id": 431,
-	  "name": "Goldbach Digital Services AG"
-	},
-	{
-	  "id": 432,
-	  "name": "Goodlife Corporation L.P."
-	},
-	{
-	  "id": 433,
-	  "name": "GoodRX, Inc."
-	},
-	{
-	  "id": 434,
-	  "name": "Google"
-	},
-	{
-	  "id": 435,
-	  "name": "Gourmet Ads Pty Limited"
-	},
-	{
-	  "id": 436,
-	  "name": "Grand Play Media LLC"
-	},
-	{
-	  "id": 437,
-	  "name": "Grandex Inc."
-	},
-	{
-	  "id": 438,
-	  "name": "Grapeshot Ltd."
-	},
-	{
-	  "id": 439,
-	  "name": "Graphiq Inc."
-	},
-	{
-	  "id": 440,
-	  "name": "Gravity4 Inc."
-	},
-	{
-	  "id": 441,
-	  "name": "Greenhouse Group B.V."
-	},
-	{
-	  "id": 442,
-	  "name": "Grm-Pro.Com"
-	},
-	{
-	  "id": 443,
-	  "name": "GroovinAds"
-	},
-	{
-	  "id": 444,
-	  "name": "Grosbill"
-	},
-	{
-	  "id": 445,
-	  "name": "GroupM [m]Platform"
-	},
-	{
-	  "id": 447,
-	  "name": "Groupon Inc."
-	},
-	{
-	  "id": 448,
-	  "name": "Grupa Wirtualna Polska S.A."
-	},
-	{
-	  "id": 449,
-	  "name": "Grupo Isec S.L."
-	},
-	{
-	  "id": 450,
-	  "name": "Gskinner.Com, Inc"
-	},
-	{
-	  "id": 451,
-	  "name": "Gssprt.Jp"
-	},
-	{
-	  "id": 452,
-	  "name": "Gumgum"
-	},
-	{
-	  "id": 453,
-	  "name": "Gumtree.com Ltd"
-	},
-	{
-	  "id": 454,
-	  "name": "GZero Ltd."
-	},
-	{
-	  "id": 455,
-	  "name": "H1 Slovakia s.r.o."
-	},
-	{
-	  "id": 456,
-	  "name": "H1.cz s.r.o."
-	},
-	{
-	  "id": 457,
-	  "name": "HABERTURK GAZETECILIK A.S"
-	},
-	{
-	  "id": 458,
-	  "name": "Hagai Shechter"
-	},
-	{
-	  "id": 459,
-	  "name": "Harry's Inc."
-	},
-	{
-	  "id": 460,
-	  "name": "Hbf Capital"
-	},
-	{
-	  "id": 461,
-	  "name": "Heals"
-	},
-	{
-	  "id": 462,
-	  "name": "Healthline Media, Inc."
-	},
-	{
-	  "id": 463,
-	  "name": "Hearst Communications Inc."
-	},
-	{
-	  "id": 464,
-	  "name": "Hearts & Science"
-	},
-	{
-	  "id": 465,
-	  "name": "Hellobank.Be"
-	},
-	{
-	  "id": 466,
-	  "name": "HelloFresh SE"
-	},
-	{
-	  "id": 467,
-	  "name": "Here Media, Inc."
-	},
-	{
-	  "id": 468,
-	  "name": "Heroku, Inc."
-	},
-	{
-	  "id": 469,
-	  "name": "Hetzner Online Gmbh"
-	},
-	{
-	  "id": 470,
-	  "name": "Hi-Media"
-	},
-	{
-	  "id": 471,
-	  "name": "Hicmobile SRL"
-	},
-	{
-	  "id": 472,
-	  "name": "Highwinds Technologies"
-	},
-	{
-	  "id": 473,
-	  "name": "Hillarys Blinds Limited"
-	},
-	{
-	  "id": 474,
-	  "name": "Hispavista S.L."
-	},
-	{
-	  "id": 475,
-	  "name": "HMP Labs, Inc."
-	},
-	{
-	  "id": 476,
-	  "name": "Hoffmann Gmbh Qualitaetswerkzeuge"
-	},
-	{
-	  "id": 477,
-	  "name": "Holywell S.A."
-	},
-	{
-	  "id": 478,
-	  "name": "Hometalk LLC"
-	},
-	{
-	  "id": 479,
-	  "name": "Hooklogic"
-	},
-	{
-	  "id": 480,
-	  "name": "Horyzon Media"
-	},
-	{
-	  "id": 481,
-	  "name": "Hospitality Alliance Ag"
-	},
-	{
-	  "id": 482,
-	  "name": "Hotpointmedia"
-	},
-	{
-	  "id": 483,
-	  "name": "Hq Gmbh"
-	},
-	{
-	  "id": 484,
-	  "name": "Hsnstore"
-	},
-	{
-	  "id": 485,
-	  "name": "Httpool D.O.O."
-	},
-	{
-	  "id": 486,
-	  "name": "Human Demand Inc."
-	},
-	{
-	  "id": 487,
-	  "name": "Hurra Communications GmbH"
-	},
-	{
-	  "id": 488,
-	  "name": "HyperS HK., Limited"
-	},
-	{
-	  "id": 489,
-	  "name": "I-Company Business Solutions B.V."
-	},
-	{
-	  "id": 490,
-	  "name": "IB Times Media Ltd."
-	},
-	{
-	  "id": 491,
-	  "name": "Ib-Ibi.Com"
-	},
-	{
-	  "id": 492,
-	  "name": "Ibillboard.Com"
-	},
-	{
-	  "id": 493,
-	  "name": "Idee. Creativmarkt Gmbh & Co. Kg"
-	},
-	{
-	  "id": 494,
-	  "name": "IDG Tech Network Inc."
-	},
-	{
-	  "id": 495,
-	  "name": "Igm Domain Name Services Limited"
-	},
-	{
-	  "id": 496,
-	  "name": "Ignitionone, Inc."
-	},
-	{
-	  "id": 497,
-	  "name": "IMDB"
-	},
-	{
-	  "id": 498,
-	  "name": "Immowelt AG"
-	},
-	{
-	  "id": 499,
-	  "name": "Immowelt Hamburg GmbH"
-	},
-	{
-	  "id": 500,
-	  "name": "Impact Radius"
-	},
-	{
-	  "id": 501,
-	  "name": "Imperial Sales & Marketing GmbH"
-	},
-	{
-	  "id": 502,
-	  "name": "Improve Digital International BV"
-	},
-	{
-	  "id": 503,
-	  "name": "Impulse Screen Media Pty. Ltd."
-	},
-	{
-	  "id": 504,
-	  "name": "Index Exchange Inc"
-	},
-	{
-	  "id": 505,
-	  "name": "Infectious Media Ltd."
-	},
-	{
-	  "id": 506,
-	  "name": "Infolinks, Inc."
-	},
-	{
-	  "id": 507,
-	  "name": "Information Och Mediasystem Stockholm Ab"
-	},
-	{
-	  "id": 508,
-	  "name": "Infospace LLC"
-	},
-	{
-	  "id": 509,
-	  "name": "Ingenierie Loisirs Developpement"
-	},
-	{
-	  "id": 510,
-	  "name": "Innity"
-	},
-	{
-	  "id": 511,
-	  "name": "Innocreative"
-	},
-	{
-	  "id": 512,
-	  "name": "Innovid Media"
-	},
-	{
-	  "id": 513,
-	  "name": "InsightExpress - Survey"
-	},
-	{
-	  "id": 514,
-	  "name": "Insticator, Inc."
-	},
-	{
-	  "id": 515,
-	  "name": "Integer Media LLC"
-	},
-	{
-	  "id": 516,
-	  "name": "Integral Ad Science, Inc."
-	},
-	{
-	  "id": 517,
-	  "name": "Integral Gmbh"
-	},
-	{
-	  "id": 518,
-	  "name": "Intelliad Media Gmbh"
-	},
-	{
-	  "id": 519,
-	  "name": "Intentiq.Com"
-	},
-	{
-	  "id": 520,
-	  "name": "Intercept Interactive"
-	},
-	{
-	  "id": 521,
-	  "name": "Interface Medien Gmbh"
-	},
-	{
-	  "id": 522,
-	  "name": "Intermarkets Inc."
-	},
-	{
-	  "id": 523,
-	  "name": "International Business Machines Corporation"
-	},
-	{
-	  "id": 524,
-	  "name": "Internet Billboard S.R.O."
-	},
-	{
-	  "id": 525,
-	  "name": "Internet Brands Inc"
-	},
-	{
-	  "id": 526,
-	  "name": "Internet Laboratory Digital S.L."
-	},
-	{
-	  "id": 527,
-	  "name": "Internet Pop Hannover Gmbh"
-	},
-	{
-	  "id": 528,
-	  "name": "Internet24 Gmbh"
-	},
-	{
-	  "id": 529,
-	  "name": "Investing Channel Inc."
-	},
-	{
-	  "id": 530,
-	  "name": "Invite Media Inc."
-	},
-	{
-	  "id": 531,
-	  "name": "IP Luxembourg Sarl"
-	},
-	{
-	  "id": 532,
-	  "name": "Ipflux.Fr"
-	},
-	{
-	  "id": 533,
-	  "name": "IPONWEB Limited"
-	},
-	{
-	  "id": 534,
-	  "name": "IponWeb(bidswitch)"
-	},
-	{
-	  "id": 535,
-	  "name": "Ipromote.Com"
-	},
-	{
-	  "id": 536,
-	  "name": "iq digital media marketing gmbh"
-	},
-	{
-	  "id": 537,
-	  "name": "Is Group Bv"
-	},
-	{
-	  "id": 538,
-	  "name": "Ixi Corporation"
-	},
-	{
-	  "id": 539,
-	  "name": "Jaduda GmbH"
-	},
-	{
-	  "id": 540,
-	  "name": "Jampp Ltd."
-	},
-	{
-	  "id": 541,
-	  "name": "Jenjo LLC"
-	},
-	{
-	  "id": 542,
-	  "name": "Jivox Corporation"
-	},
-	{
-	  "id": 543,
-	  "name": "JNJ Mobile, Inc."
-	},
-	{
-	  "id": 544,
-	  "name": "Jollydays Gmbh"
-	},
-	{
-	  "id": 545,
-	  "name": "JPMorgan Chase Bank, National Association"
-	},
-	{
-	  "id": 546,
-	  "name": "Jquery Foundation"
-	},
-	{
-	  "id": 547,
-	  "name": "Jsdelivr"
-	},
-	{
-	  "id": 548,
-	  "name": "Juice Mobile"
-	},
-	{
-	  "id": 549,
-	  "name": "Just A Pinch Recipe Club, LLC"
-	},
-	{
-	  "id": 550,
-	  "name": "Kairion Gmbh"
-	},
-	{
-	  "id": 551,
-	  "name": "Kantarworldpanel.Fr"
-	},
-	{
-	  "id": 552,
-	  "name": "Kato Capital Group Sl"
-	},
-	{
-	  "id": 553,
-	  "name": "Kaufengel Gmbh"
-	},
-	{
-	  "id": 554,
-	  "name": "KBM Group"
-	},
-	{
-	  "id": 555,
-	  "name": "Kenshoo Tld"
-	},
-	{
-	  "id": 556,
-	  "name": "Key-Systems Gmbh"
-	},
-	{
-	  "id": 557,
-	  "name": "Keyade SAS"
-	},
-	{
-	  "id": 558,
-	  "name": "Keynetic Digital LLC"
-	},
-	{
-	  "id": 559,
-	  "name": "Kik US Inc."
-	},
-	{
-	  "id": 560,
-	  "name": "Kinetic Social LLC"
-	},
-	{
-	  "id": 561,
-	  "name": "Kiosked Information System LTD"
-	},
-	{
-	  "id": 562,
-	  "name": "Klois"
-	},
-	{
-	  "id": 563,
-	  "name": "Kokteyl A.S."
-	},
-	{
-	  "id": 564,
-	  "name": "Kontekstno-mediynye tekhnologii"
-	},
-	{
-	  "id": 565,
-	  "name": "Krux Digital"
-	},
-	{
-	  "id": 566,
-	  "name": "Krxd.Net"
-	},
-	{
-	  "id": 567,
-	  "name": "Kwanzoo"
-	},
-	{
-	  "id": 568,
-	  "name": "Kwpsurveys.Com"
-	},
-	{
-	  "id": 569,
-	  "name": "Kyocera Communication Systems Co., Ltd"
-	},
-	{
-	  "id": 570,
-	  "name": "La Place Media SAS"
-	},
-	{
-	  "id": 571,
-	  "name": "Lagard_re Publicit_ SAS"
-	},
-	{
-	  "id": 572,
-	  "name": "Latinon Inc"
-	},
-	{
-	  "id": 573,
-	  "name": "LDMobile SAS (netADge)"
-	},
-	{
-	  "id": 574,
-	  "name": "Lead Alliance Gmbh"
-	},
-	{
-	  "id": 575,
-	  "name": "LemonPI"
-	},
-	{
-	  "id": 576,
-	  "name": "Leopard Mobile Ltd"
-	},
-	{
-	  "id": 577,
-	  "name": "Lerta Business Inc."
-	},
-	{
-	  "id": 578,
-	  "name": "LifeStreet Corp."
-	},
-	{
-	  "id": 579,
-	  "name": "Ligatus GmbH"
-	},
-	{
-	  "id": 580,
-	  "name": "Lijit Networks Inc."
-	},
-	{
-	  "id": 581,
-	  "name": "Lijit.Com"
-	},
-	{
-	  "id": 582,
-	  "name": "Likqid Media, Llc"
-	},
-	{
-	  "id": 583,
-	  "name": "Limelight"
-	},
-	{
-	  "id": 584,
-	  "name": "Link Marketing Services Ag"
-	},
-	{
-	  "id": 585,
-	  "name": "LINKdotNET FZ-LLC"
-	},
-	{
-	  "id": 586,
-	  "name": "LinkedIn Corp."
-	},
-	{
-	  "id": 587,
-	  "name": "Linkshare Corporation"
-	},
-	{
-	  "id": 588,
-	  "name": "Linkury LTD"
-	},
-	{
-	  "id": 589,
-	  "name": "LiquidM Technology GmbH"
-	},
-	{
-	  "id": 590,
-	  "name": "LiveIntent, Inc."
-	},
-	{
-	  "id": 591,
-	  "name": "LiveRamp Inc,"
-	},
-	{
-	  "id": 592,
-	  "name": "Liveramp Inc."
-	},
-	{
-	  "id": 593,
-	  "name": "LiveSport Media Ltd"
-	},
-	{
-	  "id": 594,
-	  "name": "Livextention Srl"
-	},
-	{
-	  "id": 595,
-	  "name": "Livingly Media, Inc"
-	},
-	{
-	  "id": 596,
-	  "name": "Local Response Inc."
-	},
-	{
-	  "id": 597,
-	  "name": "Local World Limited"
-	},
-	{
-	  "id": 598,
-	  "name": "Localsensor B.V."
-	},
-	{
-	  "id": 599,
-	  "name": "Localstars Ltd"
-	},
-	{
-	  "id": 600,
-	  "name": "Longtail Ad Solutions, Inc."
-	},
-	{
-	  "id": 601,
-	  "name": "LotaData, Inc."
-	},
-	{
-	  "id": 602,
-	  "name": "Lotame"
-	},
-	{
-	  "id": 603,
-	  "name": "Lowermybills, Inc."
-	},
-	{
-	  "id": 604,
-	  "name": "Lucia Federico"
-	},
-	{
-	  "id": 605,
-	  "name": "Luftansa"
-	},
-	{
-	  "id": 606,
-	  "name": "Lumos Labs Inc."
-	},
-	{
-	  "id": 607,
-	  "name": "M-Net Telekommunikations Gmbh"
-	},
-	{
-	  "id": 608,
-	  "name": "M3 USA Corporation"
-	},
-	{
-	  "id": 609,
-	  "name": "M32 Media Inc"
-	},
-	{
-	  "id": 610,
-	  "name": "M6R.Eu"
-	},
-	{
-	  "id": 611,
-	  "name": "Macromill.Com"
-	},
-	{
-	  "id": 612,
-	  "name": "Madison Logic Inc."
-	},
-	{
-	  "id": 613,
-	  "name": "Magnetic Media Online, Inc."
-	},
-	{
-	  "id": 614,
-	  "name": "Mamamia.com.au Pty Ltd."
-	},
-	{
-	  "id": 615,
-	  "name": "Manage.com Group, Inc"
-	},
-	{
-	  "id": 616,
-	  "name": "Mansueto Ventures"
-	},
-	{
-	  "id": 617,
-	  "name": "Mapbox"
-	},
-	{
-	  "id": 618,
-	  "name": "Marc Querling"
-	},
-	{
-	  "id": 619,
-	  "name": "Marchex.Io"
-	},
-	{
-	  "id": 620,
-	  "name": "Mark & Mini Bv"
-	},
-	{
-	  "id": 621,
-	  "name": "Markovian GmbH"
-	},
-	{
-	  "id": 622,
-	  "name": "Match.com LLC"
-	},
-	{
-	  "id": 623,
-	  "name": "Match2One AB"
-	},
-	{
-	  "id": 624,
-	  "name": "Mathads"
-	},
-	{
-	  "id": 625,
-	  "name": "Maverick Media S.L."
-	},
-	{
-	  "id": 626,
-	  "name": "MaxPoint Interactive Inc."
-	},
-	{
-	  "id": 627,
-	  "name": "MBR Targeting GmbH"
-	},
-	{
-	  "id": 628,
-	  "name": "Mcsoport Magyarorszag Kft."
-	},
-	{
-	  "id": 629,
-	  "name": "MdotM Inc."
-	},
-	{
-	  "id": 630,
-	  "name": "MDSP LIMITED"
-	},
-	{
-	  "id": 631,
-	  "name": "Media Decision Gmbh"
-	},
-	{
-	  "id": 632,
-	  "name": "Media Forum Inc."
-	},
-	{
-	  "id": 633,
-	  "name": "Media Impact GmbH & Co. KG"
-	},
-	{
-	  "id": 634,
-	  "name": "Media Impact Polska sp. zo.o"
-	},
-	{
-	  "id": 635,
-	  "name": "Media iQ Digital, Ltd."
-	},
-	{
-	  "id": 636,
-	  "name": "Media Logic Group, Llc"
-	},
-	{
-	  "id": 637,
-	  "name": "Media Planning Group S.A."
-	},
-	{
-	  "id": 638,
-	  "name": "Media-Saturn It Services"
-	},
-	{
-	  "id": 639,
-	  "name": "Media.Net Ltd."
-	},
-	{
-	  "id": 640,
-	  "name": "Media.Ventive Gmbh"
-	},
-	{
-	  "id": 641,
-	  "name": "Media6Degrees Inc."
-	},
-	{
-	  "id": 642,
-	  "name": "MediaCom Holdings Ltd."
-	},
-	{
-	  "id": 643,
-	  "name": "Mediaforce (London) Ltd"
-	},
-	{
-	  "id": 644,
-	  "name": "Mediafriends I/S"
-	},
-	{
-	  "id": 645,
-	  "name": "Mediahead AG"
-	},
-	{
-	  "id": 646,
-	  "name": "Mediamark Pty Ltd"
-	},
-	{
-	  "id": 647,
-	  "name": "MediaMath LLC"
-	},
-	{
-	  "id": 648,
-	  "name": "Medianova Internet Hizmetleri A.S."
-	},
-	{
-	  "id": 649,
-	  "name": "Mediaplex"
-	},
-	{
-	  "id": 650,
-	  "name": "Mediarithmics"
-	},
-	{
-	  "id": 651,
-	  "name": "MediaSmart Mobile S.L."
-	},
-	{
-	  "id": 652,
-	  "name": "MediaV Advertising"
-	},
-	{
-	  "id": 653,
-	  "name": "MediaVine, Inc."
-	},
-	{
-	  "id": 654,
-	  "name": "Medula Network, LLC"
-	},
-	{
-	  "id": 655,
-	  "name": "Meetrics GmbH"
-	},
-	{
-	  "id": 656,
-	  "name": "meinestadt.de GmbH"
-	},
-	{
-	  "id": 657,
-	  "name": "Melia.Com"
-	},
-	{
-	  "id": 658,
-	  "name": "Meredith Corporation"
-	},
-	{
-	  "id": 659,
-	  "name": "Merriam Webster, Inc."
-	},
-	{
-	  "id": 660,
-	  "name": "Meta Network Ltd."
-	},
-	{
-	  "id": 661,
-	  "name": "Metadata, Inc."
-	},
-	{
-	  "id": 662,
-	  "name": "Metapeople Gmbh"
-	},
-	{
-	  "id": 663,
-	  "name": "metrigo GmbH"
-	},
-	{
-	  "id": 664,
-	  "name": "MGID Inc"
-	},
-	{
-	  "id": 665,
-	  "name": "MicroAd, Inc."
-	},
-	{
-	  "id": 666,
-	  "name": "Microsoft Corporation"
-	},
-	{
-	  "id": 667,
-	  "name": "Millemercis"
-	},
-	{
-	  "id": 668,
-	  "name": "Millennial Media Inc"
-	},
-	{
-	  "id": 669,
-	  "name": "Mindlytix SAS"
-	},
-	{
-	  "id": 670,
-	  "name": "Mindshare Worldwide UK Ltd."
-	},
-	{
-	  "id": 671,
-	  "name": "Mister-Load Gmbh"
-	},
-	{
-	  "id": 672,
-	  "name": "Mittwald Cm Service Gmbh & Co Kg"
-	},
-	{
-	  "id": 673,
-	  "name": "Moat Ads"
-	},
-	{
-	  "id": 674,
-	  "name": "Mobile Professionals B.V."
-	},
-	{
-	  "id": 675,
-	  "name": "MobileFuse LLC"
-	},
-	{
-	  "id": 676,
-	  "name": "Mobilewalla"
-	},
-	{
-	  "id": 677,
-	  "name": "Mobusi Mobile Advertising S.L."
-	},
-	{
-	  "id": 678,
-	  "name": "Molora Srl"
-	},
-	{
-	  "id": 679,
-	  "name": "Monarchads.Com"
-	},
-	{
-	  "id": 680,
-	  "name": "Monkey Media Inc."
-	},
-	{
-	  "id": 681,
-	  "name": "Monster Worldwide Inc."
-	},
-	{
-	  "id": 682,
-	  "name": "Mopedo AB"
-	},
-	{
-	  "id": 683,
-	  "name": "Motesplatsen.Se"
-	},
-	{
-	  "id": 684,
-	  "name": "mov.ad GmbH"
-	},
-	{
-	  "id": 685,
-	  "name": "Move Sales, Inc."
-	},
-	{
-	  "id": 686,
-	  "name": "MPublicit_"
-	},
-	{
-	  "id": 687,
-	  "name": "Multi Channel Network Pty Ltd."
-	},
-	{
-	  "id": 688,
-	  "name": "Mvmt Watches"
-	},
-	{
-	  "id": 689,
-	  "name": "Mxptint.Net"
-	},
-	{
-	  "id": 690,
-	  "name": "My Jewellery"
-	},
-	{
-	  "id": 691,
-	  "name": "MyAdWise Ltd."
-	},
-	{
-	  "id": 692,
-	  "name": "Myfonts.Net"
-	},
-	{
-	  "id": 693,
-	  "name": "MyLikes Inc."
-	},
-	{
-	  "id": 694,
-	  "name": "Myspace Llc"
-	},
-	{
-	  "id": 695,
-	  "name": "MyThings (UK) Ltd."
-	},
-	{
-	  "id": 696,
-	  "name": "Mytoys.De Gmbh"
-	},
-	{
-	  "id": 697,
-	  "name": "Myvisualiq"
-	},
-	{
-	  "id": 698,
-	  "name": "N@Work Internet Informationssystem Gmbh"
-	},
-	{
-	  "id": 699,
-	  "name": "Nanigans Inc."
-	},
-	{
-	  "id": 700,
-	  "name": "Naspek International S.A."
-	},
-	{
-	  "id": 701,
-	  "name": "Nationwide News Pty Limited"
-	},
-	{
-	  "id": 702,
-	  "name": "Nativo, Inc."
-	},
-	{
-	  "id": 703,
-	  "name": "Naturzeit Gmbh & Co.Kg"
-	},
-	{
-	  "id": 704,
-	  "name": "Navegg S.A."
-	},
-	{
-	  "id": 705,
-	  "name": "NC Audience Exchange, LLC"
-	},
-	{
-	  "id": 706,
-	  "name": "Neodata Group"
-	},
-	{
-	  "id": 707,
-	  "name": "Net Reviews"
-	},
-	{
-	  "id": 708,
-	  "name": "Netadge"
-	},
-	{
-	  "id": 709,
-	  "name": "Netcologne Ges. Fuer Telekommunikation Mbh"
-	},
-	{
-	  "id": 710,
-	  "name": "Netcom Medya Reklam Satis Pazarlama LTD STI"
-	},
-	{
-	  "id": 711,
-	  "name": "Netdirekt A.S"
-	},
-	{
-	  "id": 712,
-	  "name": "Netdna, Llc."
-	},
-	{
-	  "id": 713,
-	  "name": "Netflix, Inc."
-	},
-	{
-	  "id": 714,
-	  "name": "Netmining LLC"
-	},
-	{
-	  "id": 715,
-	  "name": "Netnames Ltd"
-	},
-	{
-	  "id": 716,
-	  "name": "Netpoint Media GmbH"
-	},
-	{
-	  "id": 717,
-	  "name": "NetSeer, Inc."
-	},
-	{
-	  "id": 718,
-	  "name": "Netsprint S.A."
-	},
-	{
-	  "id": 719,
-	  "name": "Netzeffekt Gmbh"
-	},
-	{
-	  "id": 720,
-	  "name": "Neue Medien Muennich Gmbh"
-	},
-	{
-	  "id": 721,
-	  "name": "Neuranet Inc."
-	},
-	{
-	  "id": 722,
-	  "name": "NeuStar Inc."
-	},
-	{
-	  "id": 723,
-	  "name": "New Look Retailers Limited"
-	},
-	{
-	  "id": 724,
-	  "name": "New Relic"
-	},
-	{
-	  "id": 725,
-	  "name": "News UK & Ireland Limited"
-	},
-	{
-	  "id": 726,
-	  "name": "Newsday LLC"
-	},
-	{
-	  "id": 727,
-	  "name": "NewsNow Publishing Limited"
-	},
-	{
-	  "id": 728,
-	  "name": "Newsweb SA"
-	},
-	{
-	  "id": 729,
-	  "name": "Nexage LLC"
-	},
-	{
-	  "id": 730,
-	  "name": "Nexeps Gmbh"
-	},
-	{
-	  "id": 731,
-	  "name": "Next Audience GmbH"
-	},
-	{
-	  "id": 732,
-	  "name": "Next Performance"
-	},
-	{
-	  "id": 733,
-	  "name": "Next Tuesday Gmbh"
-	},
-	{
-	  "id": 734,
-	  "name": "Nielsen"
-	},
-	{
-	  "id": 735,
-	  "name": "Nine Digital Pty Limited"
-	},
-	{
-	  "id": 736,
-	  "name": "Ninthdecimal, Inc"
-	},
-	{
-	  "id": 737,
-	  "name": "Noris Network Ag"
-	},
-	{
-	  "id": 738,
-	  "name": "Nosto Solutions Ltd"
-	},
-	{
-	  "id": 739,
-	  "name": "Nova Ventus Consulting, S.L."
-	},
-	{
-	  "id": 740,
-	  "name": "Novem Sp. Z O.O."
-	},
-	{
-	  "id": 741,
-	  "name": "Nowspots"
-	},
-	{
-	  "id": 742,
-	  "name": "Nugg.Ad Ag Predictive Behavioral Targeting"
-	},
-	{
-	  "id": 743,
-	  "name": "Numerotron, Inc."
-	},
-	{
-	  "id": 744,
-	  "name": "NWS DIGITAL ASIA PTE LIMITED"
-	},
-	{
-	  "id": 745,
-	  "name": "NYP Holdings Inc."
-	},
-	{
-	  "id": 746,
-	  "name": "NZZ Media Solutions AG"
-	},
-	{
-	  "id": 747,
-	  "name": "O2 Holdings Limited"
-	},
-	{
-	  "id": 748,
-	  "name": "Ocom Ip B.V."
-	},
-	{
-	  "id": 749,
-	  "name": "Olihargon LLC"
-	},
-	{
-	  "id": 750,
-	  "name": "Omnicom Media Group Europe Ltd."
-	},
-	{
-	  "id": 751,
-	  "name": "Omniga Gmbh & Co. Kg"
-	},
-	{
-	  "id": 752,
-	  "name": "Omnitag Js"
-	},
-	{
-	  "id": 753,
-	  "name": "Omnium Group"
-	},
-	{
-	  "id": 754,
-	  "name": "One Advertising Ag"
-	},
-	{
-	  "id": 755,
-	  "name": "One Advertising GmBH"
-	},
-	{
-	  "id": 756,
-	  "name": "One.Com"
-	},
-	{
-	  "id": 757,
-	  "name": "OneSixty2 SAS"
-	},
-	{
-	  "id": 758,
-	  "name": "OneSpot, Inc."
-	},
-	{
-	  "id": 759,
-	  "name": "Online Solution Int Ltd"
-	},
-	{
-	  "id": 760,
-	  "name": "OnScroll Limited"
-	},
-	{
-	  "id": 761,
-	  "name": "OpenX Technologies Inc."
-	},
-	{
-	  "id": 762,
-	  "name": "Optima Network SLU"
-	},
-	{
-	  "id": 763,
-	  "name": "Optimal Fusion Inc."
-	},
-	{
-	  "id": 764,
-	  "name": "Optimatic Inc."
-	},
-	{
-	  "id": 765,
-	  "name": "Optimax Media Delivery"
-	},
-	{
-	  "id": 766,
-	  "name": "Optimizely"
-	},
-	{
-	  "id": 767,
-	  "name": "Oracle Corporation"
-	},
-	{
-	  "id": 768,
-	  "name": "Orange SA"
-	},
-	{
-	  "id": 769,
-	  "name": "Orange142, LLC"
-	},
-	{
-	  "id": 770,
-	  "name": "Orangepublicite.Fr"
-	},
-	{
-	  "id": 771,
-	  "name": "ORTEC BV"
-	},
-	{
-	  "id": 772,
-	  "name": "Otto (Gmbh & Co Kg)"
-	},
-	{
-	  "id": 773,
-	  "name": "Outbrain Inc."
-	},
-	{
-	  "id": 774,
-	  "name": "Outreach Inc."
-	},
-	{
-	  "id": 775,
-	  "name": "Outrider S.L."
-	},
-	{
-	  "id": 776,
-	  "name": "OwnerIQ Inc."
-	},
-	{
-	  "id": 777,
-	  "name": "OZ S.R.L."
-	},
-	{
-	  "id": 778,
-	  "name": "Pandora Media Inc."
-	},
-	{
-	  "id": 779,
-	  "name": "Parship Gmbh"
-	},
-	{
-	  "id": 780,
-	  "name": "Patzer, LLC"
-	},
-	{
-	  "id": 781,
-	  "name": "PBH Network Inc."
-	},
-	{
-	  "id": 782,
-	  "name": "Pelmorex Canada Inc."
-	},
-	{
-	  "id": 783,
-	  "name": "Perform Media Sales Ltd"
-	},
-	{
-	  "id": 784,
-	  "name": "Performance Advertising GmbH"
-	},
-	{
-	  "id": 785,
-	  "name": "PG Publishing Company, Inc."
-	},
-	{
-	  "id": 786,
-	  "name": "Picnic Media Ltd"
-	},
-	{
-	  "id": 787,
-	  "name": "Pinger Inc."
-	},
-	{
-	  "id": 788,
-	  "name": "Pixalate, Inc."
-	},
-	{
-	  "id": 789,
-	  "name": "Placed"
-	},
-	{
-	  "id": 790,
-	  "name": "PlaceLocal"
-	},
-	{
-	  "id": 791,
-	  "name": "Plan.Net Performance Gmbh & Co. Kg"
-	},
-	{
-	  "id": 792,
-	  "name": "Platform-One"
-	},
-	{
-	  "id": 793,
-	  "name": "PlaygroundXYZ"
-	},
-	{
-	  "id": 794,
-	  "name": "Plentymarkets Gmbh"
-	},
-	{
-	  "id": 795,
-	  "name": "Plista GmbH"
-	},
-	{
-	  "id": 796,
-	  "name": "Pmu.Fr"
-	},
-	{
-	  "id": 797,
-	  "name": "PowerLinks Media Inc."
-	},
-	{
-	  "id": 798,
-	  "name": "Predictive Pop, Inc."
-	},
-	{
-	  "id": 799,
-	  "name": "Prime Real Time BV"
-	},
-	{
-	  "id": 800,
-	  "name": "Prisa Brand Solutions, S.L."
-	},
-	{
-	  "id": 801,
-	  "name": "Program_tica de Publicidad, S.L."
-	},
-	{
-	  "id": 802,
-	  "name": "Programmatic Mechanics LLC"
-	},
-	{
-	  "id": 803,
-	  "name": "Proinity Gmbh"
-	},
-	{
-	  "id": 804,
-	  "name": "Project Sunblock"
-	},
-	{
-	  "id": 805,
-	  "name": "Psw Group Gmbh & Co. Kg"
-	},
-	{
-	  "id": 806,
-	  "name": "Publipress Media SLU"
-	},
-	{
-	  "id": 807,
-	  "name": "Publishers Clearing House"
-	},
-	{
-	  "id": 808,
-	  "name": "Pubmatic Inc."
-	},
-	{
-	  "id": 809,
-	  "name": "PubSquared LLC"
-	},
-	{
-	  "id": 810,
-	  "name": "Pulpo Media, Inc."
-	},
-	{
-	  "id": 811,
-	  "name": "PulsePoint, Inc."
-	},
-	{
-	  "id": 812,
-	  "name": "Q Audience, Corp."
-	},
-	{
-	  "id": 813,
-	  "name": "Q1Media Inc."
-	},
-	{
-	  "id": 814,
-	  "name": "Qualityhosting Ag"
-	},
-	{
-	  "id": 815,
-	  "name": "QUANT-X"
-	},
-	{
-	  "id": 816,
-	  "name": "Quantbench Corp."
-	},
-	{
-	  "id": 817,
-	  "name": "Quantcast Corp."
-	},
-	{
-	  "id": 818,
-	  "name": "Quint Growth Inc."
-	},
-	{
-	  "id": 819,
-	  "name": "Quisma GmbH"
-	},
-	{
-	  "id": 820,
-	  "name": "Quisma Netherlands B.V."
-	},
-	{
-	  "id": 821,
-	  "name": "R'publishing"
-	},
-	{
-	  "id": 822,
-	  "name": "Rackhosting.Com"
-	},
-	{
-	  "id": 823,
-	  "name": "Rackspace Us, Inc."
-	},
-	{
-	  "id": 824,
-	  "name": "RadiumOne, Inc."
-	},
-	{
-	  "id": 825,
-	  "name": "Rakuten, Inc."
-	},
-	{
-	  "id": 826,
-	  "name": "Rambla.Be"
-	},
-	{
-	  "id": 827,
-	  "name": "Ranker, Inc."
-	},
-	{
-	  "id": 828,
-	  "name": "Rant Inc"
-	},
-	{
-	  "id": 829,
-	  "name": "Reachdynamics Llc"
-	},
-	{
-	  "id": 830,
-	  "name": "Reader's Digest Sales and Services Inc."
-	},
-	{
-	  "id": 831,
-	  "name": "Realestate.com.au Pty Limited"
-	},
-	{
-	  "id": 832,
-	  "name": "RealVu Inc."
-	},
-	{
-	  "id": 833,
-	  "name": "Realzeit GmbH"
-	},
-	{
-	  "id": 834,
-	  "name": "Recoset Inc."
-	},
-	{
-	  "id": 835,
-	  "name": "Red Blue Media, LLC"
-	},
-	{
-	  "id": 836,
-	  "name": "Reduce Data Inc."
-	},
-	{
-	  "id": 837,
-	  "name": "redvertisment"
-	},
-	{
-	  "id": 838,
-	  "name": "Refined Labs Gmbh"
-	},
-	{
-	  "id": 839,
-	  "name": "RelevanC"
-	},
-	{
-	  "id": 840,
-	  "name": "Remerge GmbH"
-	},
-	{
-	  "id": 841,
-	  "name": "Renier S.A."
-	},
-	{
-	  "id": 842,
-	  "name": "Research Now Limited"
-	},
-	{
-	  "id": 843,
-	  "name": "Research-Int.Se"
-	},
-	{
-	  "id": 844,
-	  "name": "Reseau Fleuri"
-	},
-	{
-	  "id": 845,
-	  "name": "Resonate Networks"
-	},
-	{
-	  "id": 846,
-	  "name": "Reussissonsensemble.Fr"
-	},
-	{
-	  "id": 847,
-	  "name": "Revenue Cloud GmbH"
-	},
-	{
-	  "id": 848,
-	  "name": "Revjet Llc."
-	},
-	{
-	  "id": 849,
-	  "name": "Revolution Messaging LLC"
-	},
-	{
-	  "id": 850,
-	  "name": "Revpros"
-	},
-	{
-	  "id": 851,
-	  "name": "Revx, Inc."
-	},
-	{
-	  "id": 852,
-	  "name": "Rhym Exchange"
-	},
-	{
-	  "id": 853,
-	  "name": "RhythmOne LLC"
-	},
-	{
-	  "id": 854,
-	  "name": "Rich Audience International SL"
-	},
-	{
-	  "id": 855,
-	  "name": "Rich Media Studio"
-	},
-	{
-	  "id": 856,
-	  "name": "Richemont Dns Inc"
-	},
-	{
-	  "id": 857,
-	  "name": "RightAction Inc."
-	},
-	{
-	  "id": 858,
-	  "name": "Rockabox Media Ltd"
-	},
-	{
-	  "id": 859,
-	  "name": "Rockerbox, Inc"
-	},
-	{
-	  "id": 860,
-	  "name": "Rocket Fuel Inc."
-	},
-	{
-	  "id": 861,
-	  "name": "Rocket Internet SE"
-	},
-	{
-	  "id": 862,
-	  "name": "Roi Media Participacoes e Propaganda Ltda"
-	},
-	{
-	  "id": 863,
-	  "name": "RS Internet Pazarlama A.S"
-	},
-	{
-	  "id": 864,
-	  "name": "RTB House S.A."
-	},
-	{
-	  "id": 865,
-	  "name": "Run, Inc."
-	},
-	{
-	  "id": 866,
-	  "name": "Russmedia Digital GmbH"
-	},
-	{
-	  "id": 867,
-	  "name": "S&W Ltd."
-	},
-	{
-	  "id": 868,
-	  "name": "S.F.C Srl"
-	},
-	{
-	  "id": 869,
-	  "name": "SafeGraph Inc."
-	},
-	{
-	  "id": 870,
-	  "name": "Sam4Mobile"
-	},
-	{
-	  "id": 871,
-	  "name": "Samba.Tv"
-	},
-	{
-	  "id": 872,
-	  "name": "Sanoma Media Finland Oy"
-	},
-	{
-	  "id": 873,
-	  "name": "Sanoma Media Netherlands BV"
-	},
-	{
-	  "id": 874,
-	  "name": "Sarenza Sa"
-	},
-	{
-	  "id": 875,
-	  "name": "Sas"
-	},
-	{
-	  "id": 876,
-	  "name": "Save Tv Ltd."
-	},
-	{
-	  "id": 877,
-	  "name": "Scarab Research Kft"
-	},
-	{
-	  "id": 878,
-	  "name": "Scene Steeler Ltd."
-	},
-	{
-	  "id": 879,
-	  "name": "Schibsted Products & Technology UK Ltd"
-	},
-	{
-	  "id": 880,
-	  "name": "Scopely Inc."
-	},
-	{
-	  "id": 881,
-	  "name": "Scout Media Inc."
-	},
-	{
-	  "id": 882,
-	  "name": "SecondScreen LLC"
-	},
-	{
-	  "id": 883,
-	  "name": "Securenet Systems, Inc."
-	},
-	{
-	  "id": 884,
-	  "name": "Sekindo Ltd"
-	},
-	{
-	  "id": 885,
-	  "name": "Selectmedia Pte Ltd"
-	},
-	{
-	  "id": 886,
-	  "name": "Sellpoints, Inc"
-	},
-	{
-	  "id": 887,
-	  "name": "Semantic Sugar, Inc"
-	},
-	{
-	  "id": 888,
-	  "name": "Semantinet (AdExtent) Ltd."
-	},
-	{
-	  "id": 889,
-	  "name": "Semasio GmbH"
-	},
-	{
-	  "id": 890,
-	  "name": "Semcasting Inc."
-	},
-	{
-	  "id": 891,
-	  "name": "Semilo B.V."
-	},
-	{
-	  "id": 892,
-	  "name": "Seventures Europe"
-	},
-	{
-	  "id": 893,
-	  "name": "Shareably Media, LLC"
-	},
-	{
-	  "id": 894,
-	  "name": "Sharethis Inc."
-	},
-	{
-	  "id": 895,
-	  "name": "ShareThrough Inc."
-	},
-	{
-	  "id": 896,
-	  "name": "Shazam Entertainment Ltd."
-	},
-	{
-	  "id": 897,
-	  "name": "Shenzhen Tencent Computer Systems Company Limited"
-	},
-	{
-	  "id": 898,
-	  "name": "Shoplocal"
-	},
-	{
-	  "id": 899,
-	  "name": "Signal Digital, Inc."
-	},
-	{
-	  "id": 900,
-	  "name": "Simplaex GmbH"
-	},
-	{
-	  "id": 901,
-	  "name": "Simplifi Holdings, Inc."
-	},
-	{
-	  "id": 902,
-	  "name": "Simply Media Group Ltd"
-	},
-	{
-	  "id": 903,
-	  "name": "Sirdata"
-	},
-	{
-	  "id": 904,
-	  "name": "Sizmek Technologies Inc."
-	},
-	{
-	  "id": 905,
-	  "name": "Skafidia S.A."
-	},
-	{
-	  "id": 906,
-	  "name": "Skimbit Ltd"
-	},
-	{
-	  "id": 907,
-	  "name": "Skinected"
-	},
-	{
-	  "id": 908,
-	  "name": "Skout Inc."
-	},
-	{
-	  "id": 909,
-	  "name": "Skyhook Wireless, Inc."
-	},
-	{
-	  "id": 910,
-	  "name": "Slader, LLC"
-	},
-	{
-	  "id": 911,
-	  "name": "Sled, Inc."
-	},
-	{
-	  "id": 912,
-	  "name": "Smaato Inc."
-	},
-	{
-	  "id": 913,
-	  "name": "Smarcado Gmbh"
-	},
-	{
-	  "id": 914,
-	  "name": "Smart Ad Server"
-	},
-	{
-	  "id": 915,
-	  "name": "Smartclip Ag"
-	},
-	{
-	  "id": 916,
-	  "name": "Smartclip Holding AG"
-	},
-	{
-	  "id": 917,
-	  "name": "Smartketer Llc."
-	},
-	{
-	  "id": 918,
-	  "name": "Smartstream.Tv Gmbh"
-	},
-	{
-	  "id": 919,
-	  "name": "Snapsort, Inc."
-	},
-	{
-	  "id": 920,
-	  "name": "So-Net Media Networks Corp."
-	},
-	{
-	  "id": 921,
-	  "name": "Social Reality, Inc."
-	},
-	{
-	  "id": 922,
-	  "name": "Societe Air France"
-	},
-	{
-	  "id": 923,
-	  "name": "Societe Francaise Du Radiotelephone - Sfr"
-	},
-	{
-	  "id": 924,
-	  "name": "Societe Nationale Des Chemins"
-	},
-	{
-	  "id": 925,
-	  "name": "Sociomantic Labs GmbH"
-	},
-	{
-	  "id": 926,
-	  "name": "Sodel Solutions Pvt. Ltd."
-	},
-	{
-	  "id": 927,
-	  "name": "Soicos International AG"
-	},
-	{
-	  "id": 928,
-	  "name": "Sojern, Inc."
-	},
-	{
-	  "id": 929,
-	  "name": "SolarCity"
-	},
-	{
-	  "id": 930,
-	  "name": "Somo Audience Corp"
-	},
-	{
-	  "id": 931,
-	  "name": "Songo Media Ltd."
-	},
-	{
-	  "id": 932,
-	  "name": "Sonobi Inc."
-	},
-	{
-	  "id": 933,
-	  "name": "Spanfeller Media Group, Inc."
-	},
-	{
-	  "id": 934,
-	  "name": "Sparc Media Pty Ltd."
-	},
-	{
-	  "id": 935,
-	  "name": "SparkPeople Inc"
-	},
-	{
-	  "id": 936,
-	  "name": "Spartoo"
-	},
-	{
-	  "id": 937,
-	  "name": "Specific Media, Llc"
-	},
-	{
-	  "id": 938,
-	  "name": "Speedata.Fr"
-	},
-	{
-	  "id": 939,
-	  "name": "Spiceworks, Inc"
-	},
-	{
-	  "id": 940,
-	  "name": "SpinMedia Group"
-	},
-	{
-	  "id": 941,
-	  "name": "Spongecell"
-	},
-	{
-	  "id": 942,
-	  "name": "Sporcle, Inc."
-	},
-	{
-	  "id": 943,
-	  "name": "Spotify AB"
-	},
-	{
-	  "id": 944,
-	  "name": "SpotXchange Inc."
-	},
-	{
-	  "id": 945,
-	  "name": "Spoutable LLC"
-	},
-	{
-	  "id": 946,
-	  "name": "Spreadshirt, Inc."
-	},
-	{
-	  "id": 947,
-	  "name": "Spring Serve"
-	},
-	{
-	  "id": 948,
-	  "name": "Ssix.Io"
-	},
-	{
-	  "id": 949,
-	  "name": "Statiq Ltd"
-	},
-	{
-	  "id": 950,
-	  "name": "Stayfriends Gmbh"
-	},
-	{
-	  "id": 951,
-	  "name": "Steel House Media"
-	},
-	{
-	  "id": 952,
-	  "name": "Sticky ADS TV S.A."
-	},
-	{
-	  "id": 953,
-	  "name": "Stiefelparadies Gmbh"
-	},
-	{
-	  "id": 954,
-	  "name": "StreamAMP Ltd"
-	},
-	{
-	  "id": 955,
-	  "name": "Streameye.Net"
-	},
-	{
-	  "id": 956,
-	  "name": "Streamrail.Com"
-	},
-	{
-	  "id": 957,
-	  "name": "Streamrail.Net"
-	},
-	{
-	  "id": 958,
-	  "name": "Ströer Digital Media GmbH"
-	},
-	{
-	  "id": 959,
-	  "name": "Study Mode, LLC"
-	},
-	{
-	  "id": 960,
-	  "name": "StudyBreak Media"
-	},
-	{
-	  "id": 961,
-	  "name": "Sublime Skinz SAS"
-	},
-	{
-	  "id": 962,
-	  "name": "Suite 66"
-	},
-	{
-	  "id": 963,
-	  "name": "Supership Inc."
-	},
-	{
-	  "id": 964,
-	  "name": "Swaven Sas"
-	},
-	{
-	  "id": 965,
-	  "name": "Switch Concepts Ltd."
-	},
-	{
-	  "id": 966,
-	  "name": "Switchads.Com"
-	},
-	{
-	  "id": 967,
-	  "name": "Syncrement, Inc."
-	},
-	{
-	  "id": 968,
-	  "name": "Synexus Gmbh"
-	},
-	{
-	  "id": 969,
-	  "name": "Synovite"
-	},
-	{
-	  "id": 970,
-	  "name": "Synovite Bv"
-	},
-	{
-	  "id": 971,
-	  "name": "Syseleven Hostmaster"
-	},
-	{
-	  "id": 972,
-	  "name": "T-Mobile"
-	},
-	{
-	  "id": 973,
-	  "name": "T-Systems International Gmbh"
-	},
-	{
-	  "id": 974,
-	  "name": "TabMo SAS"
-	},
-	{
-	  "id": 975,
-	  "name": "Taboola Inc."
-	},
-	{
-	  "id": 976,
-	  "name": "Tactic Real-Time Marketing As"
-	},
-	{
-	  "id": 977,
-	  "name": "Taggify, Inc."
-	},
-	{
-	  "id": 978,
-	  "name": "TagMan"
-	},
-	{
-	  "id": 979,
-	  "name": "Tailwind EMEA Ltd"
-	},
-	{
-	  "id": 980,
-	  "name": "Tamedia AG"
-	},
-	{
-	  "id": 981,
-	  "name": "TapAd Inc."
-	},
-	{
-	  "id": 982,
-	  "name": "TapCommerce"
-	},
-	{
-	  "id": 983,
-	  "name": "TAPTAP Networks, S.L"
-	},
-	{
-	  "id": 984,
-	  "name": "Taptica International Ltd."
-	},
-	{
-	  "id": 985,
-	  "name": "Targus Information Corporation"
-	},
-	{
-	  "id": 986,
-	  "name": "Teads France SAS"
-	},
-	{
-	  "id": 987,
-	  "name": "Tealium Inc"
-	},
-	{
-	  "id": 988,
-	  "name": "Technorati"
-	},
-	{
-	  "id": 989,
-	  "name": "Technorati Inc."
-	},
-	{
-	  "id": 990,
-	  "name": "TEG Pty Ltd."
-	},
-	{
-	  "id": 991,
-	  "name": "Telaria, Inc."
-	},
-	{
-	  "id": 992,
-	  "name": "Telefonica Germany Gmbh Und Co. Ohg"
-	},
-	{
-	  "id": 993,
-	  "name": "Telegraph Media Group Ltd."
-	},
-	{
-	  "id": 994,
-	  "name": "Telemetry Inc."
-	},
-	{
-	  "id": 995,
-	  "name": "Teletrax BV"
-	},
-	{
-	  "id": 996,
-	  "name": "Tell Apart Inc."
-	},
-	{
-	  "id": 997,
-	  "name": "Teq B.V."
-	},
-	{
-	  "id": 998,
-	  "name": "Tersai Corporation"
-	},
-	{
-	  "id": 999,
-	  "name": "Thalia Bucher Gmbh"
-	},
-	{
-	  "id": 1000,
-	  "name": "The Adex Gmbh"
-	},
-	{
-	  "id": 1001,
-	  "name": "The Blogger Network"
-	},
-	{
-	  "id": 1002,
-	  "name": "The Daily Dot LLC"
-	},
-	{
-	  "id": 1003,
-	  "name": "The Exchange Lab Ltd."
-	},
-	{
-	  "id": 1004,
-	  "name": "The Financial Times Limited"
-	},
-	{
-	  "id": 1005,
-	  "name": "The Globe and Mail Inc."
-	},
-	{
-	  "id": 1006,
-	  "name": "The Guardian News & Media Ltd"
-	},
-	{
-	  "id": 1007,
-	  "name": "The Mcgraw-Hill Companies, Inc."
-	},
-	{
-	  "id": 1008,
-	  "name": "The Moneytizer SARL"
-	},
-	{
-	  "id": 1009,
-	  "name": "The NASDAQ Inc."
-	},
-	{
-	  "id": 1010,
-	  "name": "The New York Times Company"
-	},
-	{
-	  "id": 1011,
-	  "name": "The Publisher Desk LLC"
-	},
-	{
-	  "id": 1012,
-	  "name": "The Rubicon Project Inc."
-	},
-	{
-	  "id": 1013,
-	  "name": "The Sporting Exchange Ltd"
-	},
-	{
-	  "id": 1014,
-	  "name": "The Trade Desk Inc."
-	},
-	{
-	  "id": 1015,
-	  "name": "The Wall Street Journal, Inc."
-	},
-	{
-	  "id": 1016,
-	  "name": "The Weather Channel LLC"
-	},
-	{
-	  "id": 1017,
-	  "name": "Thomson"
-	},
-	{
-	  "id": 1018,
-	  "name": "Thunder"
-	},
-	{
-	  "id": 1019,
-	  "name": "Tidaltv.Com"
-	},
-	{
-	  "id": 1020,
-	  "name": "Time Inc UK Ltd"
-	},
-	{
-	  "id": 1021,
-	  "name": "Tmrg, Inc"
-	},
-	{
-	  "id": 1022,
-	  "name": "Top Concepts Gmbh"
-	},
-	{
-	  "id": 1023,
-	  "name": "Topix LLC"
-	},
-	{
-	  "id": 1024,
-	  "name": "Totaljobs Group"
-	},
-	{
-	  "id": 1025,
-	  "name": "Townsend & O?Leary Enterprises, Inc."
-	},
-	{
-	  "id": 1026,
-	  "name": "TradeDoubler AB"
-	},
-	{
-	  "id": 1027,
-	  "name": "TradeLab"
-	},
-	{
-	  "id": 1028,
-	  "name": "Trademob GmbH"
-	},
-	{
-	  "id": 1029,
-	  "name": "Tradetracker International Bv"
-	},
-	{
-	  "id": 1030,
-	  "name": "Translease International Ltd."
-	},
-	{
-	  "id": 1031,
-	  "name": "Travel Audience GmbH"
-	},
-	{
-	  "id": 1032,
-	  "name": "Tremor Video"
-	},
-	{
-	  "id": 1033,
-	  "name": "Tremorhub.Com"
-	},
-	{
-	  "id": 1034,
-	  "name": "Triapodi Ltd."
-	},
-	{
-	  "id": 1035,
-	  "name": "Tribal Fusion"
-	},
-	{
-	  "id": 1036,
-	  "name": "Tripadvisor Llc"
-	},
-	{
-	  "id": 1037,
-	  "name": "Tripartz B.V"
-	},
-	{
-	  "id": 1038,
-	  "name": "TripleLift Inc."
-	},
-	{
-	  "id": 1039,
-	  "name": "Trkn.Us"
-	},
-	{
-	  "id": 1040,
-	  "name": "True Ultimate Standards Everywhere Inc."
-	},
-	{
-	  "id": 1041,
-	  "name": "TruSignal Inc."
-	},
-	{
-	  "id": 1042,
-	  "name": "Trusted Shops Gmbh"
-	},
-	{
-	  "id": 1043,
-	  "name": "Trustwave Holdings, Inc"
-	},
-	{
-	  "id": 1044,
-	  "name": "TubeMogul Inc."
-	},
-	{
-	  "id": 1045,
-	  "name": "Turboadv.Com"
-	},
-	{
-	  "id": 1046,
-	  "name": "Turbobytes B.V."
-	},
-	{
-	  "id": 1047,
-	  "name": "Turn Inc."
-	},
-	{
-	  "id": 1048,
-	  "name": "Turner Broadcasting Europe"
-	},
-	{
-	  "id": 1049,
-	  "name": "TVTY SA"
-	},
-	{
-	  "id": 1050,
-	  "name": "Twitter, Inc."
-	},
-	{
-	  "id": 1051,
-	  "name": "Twyn Group It Solutions And Marketing Services Ag"
-	},
-	{
-	  "id": 1052,
-	  "name": "UAB ADTARGET.ME"
-	},
-	{
-	  "id": 1053,
-	  "name": "UAB Platform Lunar"
-	},
-	{
-	  "id": 1054,
-	  "name": "Uber AdNetwork FZC"
-	},
-	{
-	  "id": 1055,
-	  "name": "Uber Technologies Inc."
-	},
-	{
-	  "id": 1056,
-	  "name": "Ubimo"
-	},
-	{
-	  "id": 1057,
-	  "name": "Ubs Ag"
-	},
-	{
-	  "id": 1058,
-	  "name": "Umzugsauktion GmbH & Co. KG"
-	},
-	{
-	  "id": 1059,
-	  "name": "UnderDog Media LLC"
-	},
-	{
-	  "id": 1060,
-	  "name": "Undertone"
-	},
-	{
-	  "id": 1061,
-	  "name": "United Inc."
-	},
-	{
-	  "id": 1062,
-	  "name": "United Internet Media GmbH"
-	},
-	{
-	  "id": 1063,
-	  "name": "United, Inc."
-	},
-	{
-	  "id": 1064,
-	  "name": "Unitymedia Nrw Gmbh"
-	},
-	{
-	  "id": 1065,
-	  "name": "Univide.Com"
-	},
-	{
-	  "id": 1066,
-	  "name": "Unlimited Standards"
-	},
-	{
-	  "id": 1067,
-	  "name": "Unlockd Media Inc."
-	},
-	{
-	  "id": 1068,
-	  "name": "Unruly Group Ltd."
-	},
-	{
-	  "id": 1069,
-	  "name": "up-value"
-	},
-	{
-	  "id": 1070,
-	  "name": "Upfront Digital Media"
-	},
-	{
-	  "id": 1071,
-	  "name": "Ureka Media Corporation"
-	},
-	{
-	  "id": 1072,
-	  "name": "USA TODAY Sports Media Group, LLC"
-	},
-	{
-	  "id": 1073,
-	  "name": "Userreport"
-	},
-	{
-	  "id": 1074,
-	  "name": "ValueClick"
-	},
-	{
-	  "id": 1075,
-	  "name": "Varick Media Management LLC"
-	},
-	{
-	  "id": 1076,
-	  "name": "Vdopia Inc."
-	},
-	{
-	  "id": 1077,
-	  "name": "Ve Interactive LLC"
-	},
-	{
-	  "id": 1078,
-	  "name": "Ve Interactive Ltd"
-	},
-	{
-	  "id": 1079,
-	  "name": "Ve Interactive Ltd."
-	},
-	{
-	  "id": 1080,
-	  "name": "Vegasystems Gmbh & Co. Kg"
-	},
-	{
-	  "id": 1081,
-	  "name": "Vemba Inc."
-	},
-	{
-	  "id": 1082,
-	  "name": "Verizon"
-	},
-	{
-	  "id": 1083,
-	  "name": "Verta Media"
-	},
-	{
-	  "id": 1084,
-	  "name": "Vertical Health, LLC"
-	},
-	{
-	  "id": 1085,
-	  "name": "Vertical Media GmbH"
-	},
-	{
-	  "id": 1086,
-	  "name": "Vertical Scope Inc."
-	},
-	{
-	  "id": 1087,
-	  "name": "Vertika Alkalmazas-Szolgaltato Kft."
-	},
-	{
-	  "id": 1088,
-	  "name": "Veruta Inc"
-	},
-	{
-	  "id": 1089,
-	  "name": "Viant US LLC"
-	},
-	{
-	  "id": 1090,
-	  "name": "Vibrant Media Inc."
-	},
-	{
-	  "id": 1091,
-	  "name": "Vidazoo"
-	},
-	{
-	  "id": 1092,
-	  "name": "Videoamp.Com"
-	},
-	{
-	  "id": 1093,
-	  "name": "Videohub Dsp"
-	},
-	{
-	  "id": 1094,
-	  "name": "Videoplaza"
-	},
-	{
-	  "id": 1095,
-	  "name": "Vidible, Inc."
-	},
-	{
-	  "id": 1096,
-	  "name": "Viglink"
-	},
-	{
-	  "id": 1097,
-	  "name": "Vimeo, Llc"
-	},
-	{
-	  "id": 1098,
-	  "name": "ViralGains Inc."
-	},
-	{
-	  "id": 1099,
-	  "name": "Virool.Com"
-	},
-	{
-	  "id": 1100,
-	  "name": "Visible Measures Corp"
-	},
-	{
-	  "id": 1101,
-	  "name": "Visualdna.Com"
-	},
-	{
-	  "id": 1102,
-	  "name": "Vix, Inc."
-	},
-	{
-	  "id": 1103,
-	  "name": "Vizury Interactive Solutions Pvt Ltd"
-	},
-	{
-	  "id": 1104,
-	  "name": "Vodafone Gmbh"
-	},
-	{
-	  "id": 1105,
-	  "name": "Voicefive"
-	},
-	{
-	  "id": 1106,
-	  "name": "VoodooVox Inc."
-	},
-	{
-	  "id": 1107,
-	  "name": "Vpon Limited"
-	},
-	{
-	  "id": 1108,
-	  "name": "Vserv Digital Services Pte Ltd."
-	},
-	{
-	  "id": 1109,
-	  "name": "W M Web Media Ltd"
-	},
-	{
-	  "id": 1110,
-	  "name": "Wal-Mart Stores Inc."
-	},
-	{
-	  "id": 1111,
-	  "name": "Wavecon Content Delivery Gmbh"
-	},
-	{
-	  "id": 1112,
-	  "name": "Way2Traffic"
-	},
-	{
-	  "id": 1113,
-	  "name": "Wayfair LLC"
-	},
-	{
-	  "id": 1114,
-	  "name": "Waypoint Media"
-	},
-	{
-	  "id": 1115,
-	  "name": "WebAds Europe Holding B.V."
-	},
-	{
-	  "id": 1116,
-	  "name": "WEBEDIA"
-	},
-	{
-	  "id": 1117,
-	  "name": "WebFinance, Inc."
-	},
-	{
-	  "id": 1118,
-	  "name": "Webgains Ltd"
-	},
-	{
-	  "id": 1119,
-	  "name": "Weborama NL B.V."
-	},
-	{
-	  "id": 1120,
-	  "name": "Webperformance Srl"
-	},
-	{
-	  "id": 1121,
-	  "name": "Wehkamp B.V."
-	},
-	{
-	  "id": 1122,
-	  "name": "WeSee Ltd."
-	},
-	{
-	  "id": 1123,
-	  "name": "Westdeutsche Lotterie Gmbh & Co. Ohg"
-	},
-	{
-	  "id": 1124,
-	  "name": "White Ops, Inc"
-	},
-	{
-	  "id": 1125,
-	  "name": "Wind Telecomunicazioni S.P.A."
-	},
-	{
-	  "id": 1126,
-	  "name": "Wobcom Gmbh Wolfsburg"
-	},
-	{
-	  "id": 1127,
-	  "name": "Wolle Roedel Gmbh & Co. Kg"
-	},
-	{
-	  "id": 1128,
-	  "name": "Wolters Kluwer Deutschland Gmbh"
-	},
-	{
-	  "id": 1129,
-	  "name": "World4You Internet Services Gmbh"
-	},
-	{
-	  "id": 1130,
-	  "name": "Wtp101.Com"
-	},
-	{
-	  "id": 1131,
-	  "name": "wywy GmbH"
-	},
-	{
-	  "id": 1132,
-	  "name": "X Plus One"
-	},
-	{
-	  "id": 1133,
-	  "name": "Xad, Inc."
-	},
-	{
-	  "id": 1135,
-	  "name": "Xb.Lc"
-	},
-	{
-	  "id": 1136,
-	  "name": "Xertive Media"
-	},
-	{
-	  "id": 1137,
-	  "name": "Xichuang Advertising Suzhou Co., Ltd."
-	},
-	{
-	  "id": 1138,
-	  "name": "Xplore, Inc."
-	},
-	{
-	  "id": 1139,
-	  "name": "Xumo, LLC"
-	},
-	{
-	  "id": 1140,
-	  "name": "Yahoo Japan Corporation"
-	},
-	{
-	  "id": 1141,
-	  "name": "Yahoo! Inc"
-	},
-	{
-	  "id": 1142,
-	  "name": "Yahoo! Inc."
-	},
-	{
-	  "id": 1143,
-	  "name": "Yandex, LLC"
-	},
-	{
-	  "id": 1144,
-	  "name": "Yard Associates Ltd"
-	},
-	{
-	  "id": 1145,
-	  "name": "Yashi, Inc"
-	},
-	{
-	  "id": 1146,
-	  "name": "Yellowhammer Media Group Inc."
-	},
-	{
-	  "id": 1147,
-	  "name": "Yelp Ireland Ltd"
-	},
-	{
-	  "id": 1148,
-	  "name": "YIELDBIRD Sp. z o. o."
-	},
-	{
-	  "id": 1149,
-	  "name": "Yieldlab Ag"
-	},
-	{
-	  "id": 1150,
-	  "name": "Yieldlove GmbH"
-	},
-	{
-	  "id": 1151,
-	  "name": "Yieldoptimizer.Com"
-	},
-	{
-	  "id": 1152,
-	  "name": "YieldR UK Limited"
-	},
-	{
-	  "id": 1153,
-	  "name": "Yoki Network B.V."
-	},
-	{
-	  "id": 1154,
-	  "name": "Yoptima Media Solutions Pvt. Ltd."
-	},
-	{
-	  "id": 1155,
-	  "name": "Ysance"
-	},
-	{
-	  "id": 1156,
-	  "name": "YuMe"
-	},
-	{
-	  "id": 1157,
-	  "name": "Zalando AG"
-	},
-	{
-	  "id": 1158,
-	  "name": "Zanox Ag"
-	},
-	{
-	  "id": 1159,
-	  "name": "Zebestof"
-	},
-	{
-	  "id": 1160,
-	  "name": "Zebestof SAS"
-	},
-	{
-	  "id": 1161,
-	  "name": "Zebrafish Labs"
-	},
-	{
-	  "id": 1162,
-	  "name": "Zedo Inc."
-	},
-	{
-	  "id": 1163,
-	  "name": "Zemanta, Inc."
-	},
-	{
-	  "id": 1164,
-	  "name": "ZenithOptimedia LTD"
-	},
-	{
-	  "id": 1165,
-	  "name": "Zeta Interactive Corp."
-	},
-	{
-	  "id": 1166,
-	  "name": "Zeus Enterprise Ltd"
-	},
-	{
-	  "id": 1167,
-	  "name": "Ziff Davis LLC"
-	},
-	{
-	  "id": 1168,
-	  "name": "Zillow Group Inc"
-	},
-	{
-	  "id": 1169,
-	  "name": "Zodiak Active Plus S.P.A"
-	},
-	{
-	  "id": 1170,
-	  "name": "ZPG Limited"
-	},
-	{
-	  "id": 1171,
-	  "name": "Ztsrv.Com"
-	}
-  ]
+    "vendorListVersion": 14,
+    "lastUpdated": "2018-05-04T15:56:34Z",
+    "purposes": [
+        {
+            "id": 1,
+            "name": "Information storage and access",
+            "description": "The storage of information, or access to information that is already stored, on your device such as advertising identifiers, device identifiers, cookies, and similar technologies."
+        },
+        {
+            "id": 2,
+            "name": "Personalisation",
+            "description": "The collection and processing of information about your use of this service to subsequently personalise advertising and/or content for you in other contexts, such as on other websites or apps, over time. Typically, the content of the site or app is used to make inferences about your interests, which inform future selection of advertising and/or content."
+        },
+        {
+            "id": 3,
+            "name": "Ad selection, delivery, reporting",
+            "description": "The collection of information, and combination with previously collected information, to select and deliver advertisements for you, and to measure the delivery and effectiveness of such advertisements. This includes using previously collected information about your interests to select ads, processing data about what advertisements were shown, how often they were shown, when and where they were shown, and whether you took any action related to the advertisement, including for example clicking an ad or making a purchase. This does not include personalisation, which is the collection and processing of information about your use of this service to subsequently personalise advertising and/or content for you in other contexts, such as websites or apps, over time."
+        },
+        {
+            "id": 4,
+            "name": "Content selection, delivery, reporting",
+            "description": "The collection of information, and combination with previously collected information, to select and deliver content for you, and to measure the delivery and effectiveness of such content. This includes using previously collected information about your interests to select content, processing data about what content was shown, how often or how long it was shown, when and where it was shown, and whether the you took any action related to the content, including for example clicking on content. This does not include personalisation, which is the collection and processing of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, such as websites or apps, over time."
+        },
+        {
+            "id": 5,
+            "name": "Measurement",
+            "description": "The collection of information about your use of the content, and combination with previously collected information, used to measure, understand, and report on your usage of the service. This does not include personalisation, the collection of information about your use of this service to subsequently personalise content and/or advertising for you in other contexts, i.e. on other service, such as websites or apps, over time."
+        }
+    ],
+    "features": [
+        {
+            "id": 1,
+            "name": "Matching Data to Offline Sources",
+            "description": "Combining data from offline sources that were initially collected in other contexts."
+        },
+        {
+            "id": 2,
+            "name": "Linking Devices",
+            "description": "Allow processing of a user's data to connect such user across multiple devices."
+        },
+        {
+            "id": 3,
+            "name": "Precise Geographic Location Data",
+            "description": "Allow processing of a user's precise geographic location data in support of a purpose for which that certain third party has consent."
+        }
+    ],
+    "vendors": [
+        {
+            "id": 8,
+            "name": "Emerse Sverige AB",
+            "policyUrl": "https://www.emerse.com/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                4
+            ],
+            "legIntPurposeIds": [
+                3,
+                5
+            ],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 12,
+            "name": "BeeswaxIO Corporation",
+            "policyUrl": "https://www.beeswax.com/privacy.html",
+            "purposeIds": [
+                1,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 28,
+            "name": "TripleLift, Inc.",
+            "policyUrl": "https://triplelift.com/privacy/",
+            "purposeIds": [
+                1,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 9,
+            "name": "AdMaxim Inc.",
+            "policyUrl": "http://www.admaxim.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 27,
+            "name": "ADventori SAS",
+            "policyUrl": "https://www.adventori.com/with-us/legal-notice/",
+            "purposeIds": [
+                2
+            ],
+            "legIntPurposeIds": [
+                1,
+                3,
+                4,
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 25,
+            "name": "Oath (EMEA) Limited",
+            "policyUrl": "https://policies.oath.com/ie/en/oath/privacy/index.html",
+            "purposeIds": [
+                1,
+                2
+            ],
+            "legIntPurposeIds": [
+                3,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 26,
+            "name": "Venatus Media Limited",
+            "policyUrl": "https://www.venatusmedia.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 1,
+            "name": "Exponential Interactive, Inc",
+            "policyUrl": "http://exponential.com/privacy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 6,
+            "name": "AdSpirit GmbH",
+            "policyUrl": "http://www.adspirit.de/privacy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 30,
+            "name": "BidTheatre AB",
+            "policyUrl": "https://www.bidtheatre.com/privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 24,
+            "name": "Conversant Europe Ltd.",
+            "policyUrl": "https://www.conversantmedia.eu/legal/privacy-policy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 29,
+            "name": "Etarget SE",
+            "policyUrl": "https://www.etarget.sk/privacy.php",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1
+            ]
+        },
+        {
+            "id": 39,
+            "name": "ADITION technologies AG",
+            "policyUrl": "adition.com/datenschutz",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 11,
+            "name": "Quantcast International Limited",
+            "policyUrl": "https://www.quantcast.com/privacy/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1
+            ]
+        },
+        {
+            "id": 15,
+            "name": "Adikteev",
+            "policyUrl": "https://www.adikteev.com/eu/privacy/",
+            "purposeIds": [
+                1,
+                2
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 4,
+            "name": "Roq.ad GmbH",
+            "policyUrl": "https://www.roq.ad/privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 7,
+            "name": "Vibrant Media Limited",
+            "policyUrl": "https://www.vibrantmedia.com/en/privacy-policy/",
+            "purposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [
+                1
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 2,
+            "name": "Captify Technologies Limited",
+            "policyUrl": "http://www.captify.co.uk/privacy-policy/",
+            "purposeIds": [
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [
+                1
+            ],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 37,
+            "name": "NEURAL.ONE",
+            "policyUrl": "https://web.neural.one/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 13,
+            "name": "Sovrn Holdings Inc",
+            "policyUrl": "https://www.sovrn.com/sovrn-privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 34,
+            "name": "NEORY GmbH",
+            "policyUrl": "https://www.neory.com/privacy.html",
+            "purposeIds": [
+                1,
+                2,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [
+                3
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 32,
+            "name": "AppNexus Inc.",
+            "policyUrl": "https://www.appnexus.com/en/company/platform-privacy-policy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                3
+            ],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 10,
+            "name": "Index Exchange, Inc. ",
+            "policyUrl": "www.indexexchange.com/privacy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 57,
+            "name": "ADARA MEDIA UNLIMITED",
+            "policyUrl": "https://adara.com/2018/04/10/adara-gdpr-faq/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 63,
+            "name": "Avocet Systems Limited",
+            "policyUrl": "http://www.avocet.io/privacy-policy",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                3
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 51,
+            "name": "xAd, Inc. dba GroundTruth",
+            "policyUrl": "https://www.groundtruth.com/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 49,
+            "name": "Tradelab, SAS",
+            "policyUrl": "http://tradelab.com/en/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 45,
+            "name": "Smart Adserver",
+            "policyUrl": "http://smartadserver.com/company/privacy-policy/",
+            "purposeIds": [
+                1,
+                2
+            ],
+            "legIntPurposeIds": [
+                3,
+                5
+            ],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 52,
+            "name": "The Rubicon Project, Limited",
+            "policyUrl": "http://rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 35,
+            "name": "Purch Group, Inc.",
+            "policyUrl": "http://www.purch.com/privacy-policy/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                3,
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 71,
+            "name": "Dataxu, Inc. ",
+            "policyUrl": "https://www.dataxu.com/about-us/privacy/data-collection-platform/",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 79,
+            "name": "MediaMath, Inc.",
+            "policyUrl": "http://www.mediamath.com/privacy-policy/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 91,
+            "name": "Criteo SA",
+            "policyUrl": "https://www.criteo.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 85,
+            "name": "Crimtan Holdings Limited",
+            "policyUrl": "https://crimtan.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 16,
+            "name": "RTB House S.A.",
+            "policyUrl": "https://www.rtbhouse.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 86,
+            "name": "Scene Stealer Limited",
+            "policyUrl": "http://scenestealer.tv/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 94,
+            "name": "Blis Media Limited",
+            "policyUrl": "http://www.blis.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 73,
+            "name": "Simplifi Holdings Inc.",
+            "policyUrl": "https://www.simpli.fi/site-privacy-policy2/",
+            "purposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [
+                1
+            ],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 67,
+            "name": "LifeStreet Corporation",
+            "policyUrl": "http://www.lifestreet.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 33,
+            "name": "ShareThis, Inc.",
+            "policyUrl": "http://www.sharethis.com/privacy/",
+            "purposeIds": [
+                3,
+                4
+            ],
+            "legIntPurposeIds": [
+                1,
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 20,
+            "name": "N Technologies Inc.",
+            "policyUrl": "https://n.rich/privacy-notice",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 55,
+            "name": "Madison Logic, Inc.",
+            "policyUrl": "https://www.madisonlogic.com/privacy/",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 53,
+            "name": "Sirdata",
+            "policyUrl": "https://www.sirdata.com/privacy/",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 69,
+            "name": "OpenX Software Ltd. and its affiliates",
+            "policyUrl": "https://www.openx.com/legal/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 98,
+            "name": "mPlatform",
+            "policyUrl": "https://www.groupm.com/mplatform-privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposeIds": [
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 62,
+            "name": "Justpremium BV",
+            "policyUrl": "http://justpremium.com/privacy-policy/",
+            "purposeIds": [
+                1,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 19,
+            "name": "Intent Media, Inc.",
+            "policyUrl": "https://intentmedia.com/privacy-policy/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 43,
+            "name": "Vdopia DBA Chocolate Platform",
+            "policyUrl": "https://chocolateplatform.com/privacy-policy/",
+            "purposeIds": [
+                1,
+                3
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 36,
+            "name": "RhythmOne, LLC",
+            "policyUrl": "https://www.rhythmone.com/privacy-policy",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 80,
+            "name": "Sharethrough, Inc",
+            "policyUrl": "https://platform-cdn.sharethrough.com/privacy-policy",
+            "purposeIds": [
+                3,
+                5
+            ],
+            "legIntPurposeIds": [
+                1
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 81,
+            "name": "PulsePoint, Inc.",
+            "policyUrl": "https://www.pulsepoint.com/privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 23,
+            "name": "Amobee, Inc. ",
+            "policyUrl": "https://www.amobee.com/trust/privacy-guidelines",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 75,
+            "name": "M32 Media Inc",
+            "policyUrl": "https://m32.media/privacy-cookie-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 17,
+            "name": "Greenhouse Group BV (with its trademark LemonPI)",
+            "policyUrl": "https://www.lemonpi.io/privacy-policy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 61,
+            "name": "GumGum, Inc.",
+            "policyUrl": "https://gumgum.com/privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 40,
+            "name": "Active Agent AG",
+            "policyUrl": "http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 76,
+            "name": "PubMatic, Inc.",
+            "policyUrl": "https://pubmatic.com/privacy-policy/",
+            "purposeIds": [
+                1,
+                2
+            ],
+            "legIntPurposeIds": [
+                3,
+                4,
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 89,
+            "name": "Tapad, Inc. ",
+            "policyUrl": "https://www.tapad.com/privacy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                5
+            ],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 46,
+            "name": "Skimbit Ltd",
+            "policyUrl": "https://skimlinks.com/pages/privacy-policy",
+            "purposeIds": [
+                1,
+                2,
+                3
+            ],
+            "legIntPurposeIds": [
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 66,
+            "name": "adsquare GmbH",
+            "policyUrl": "www.adsquare.com/privacy",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 105,
+            "name": "Impression Desk Technologies Limited",
+            "policyUrl": "impressiondesk.com",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": 41,
+            "name": "Adverline",
+            "policyUrl": "https://www.adverline.com/privacy/",
+            "purposeIds": [
+                2
+            ],
+            "legIntPurposeIds": [
+                1,
+                3
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 3,
+            "name": "affilinet",
+            "policyUrl": "https://www.affili.net/de/footeritem/datenschutz",
+            "purposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 82,
+            "name": "Smaato, Inc.",
+            "policyUrl": "https://www.smaato.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 60,
+            "name": "Rakuten Marketing LLC",
+            "policyUrl": "https://rakutenmarketing.com/legal-notices/services-privacy-policy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 70,
+            "name": "Yieldlab AG",
+            "policyUrl": "http://www.yieldlab.de/meta-navigation/datenschutz/",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                3
+            ],
+            "featureIds": [
+                3
+            ]
+        },
+        {
+            "id": 50,
+            "name": "Adform A/S",
+            "policyUrl": "https://site.adform.com/privacy-policy-opt-out/",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 48,
+            "name": "NetSuccess, s.r.o.",
+            "policyUrl": "https://www.inres.sk/pp/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 100,
+            "name": "Fifty Technology Limited",
+            "policyUrl": "https://fiftymedia.com/privacy-policy/",
+            "purposeIds": [
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [
+                1
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 21,
+            "name": "The Trade Desk, Inc and affiliated companies",
+            "policyUrl": "https://www.thetradedesk.com/general/privacy-policy",
+            "purposeIds": [
+                1,
+                2
+            ],
+            "legIntPurposeIds": [
+                3
+            ],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": 110,
+            "name": "Hottraffic BV (DMA Institute)",
+            "policyUrl": "https://www.dma-institute.com/additional-information-for-data-subjects/",
+            "purposeIds": [],
+            "legIntPurposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": []
+        },
+        {
+            "id": 42,
+            "name": "Taboola Europe Limited",
+            "policyUrl": "https://www.taboola.com/privacy-policy",
+            "purposeIds": [
+                1
+            ],
+            "legIntPurposeIds": [
+                2,
+                3,
+                4,
+                5
+            ],
+            "featureIds": [
+                1,
+                2
+            ]
+        },
+        {
+            "id": 112,
+            "name": "Maytrics GmbH",
+            "policyUrl": "https://maytrics.com/node/2",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": []
+        },
+        {
+            "id": 77,
+            "name": "comScore, Inc.",
+            "policyUrl": "https://www.comscore.com/About-comScore/Privacy-Policy",
+            "purposeIds": [
+                1,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                2
+            ]
+        },
+        {
+            "id": 109,
+            "name": "LoopMe Ltd",
+            "policyUrl": "https://loopme.com/privacy/",
+            "purposeIds": [
+                1,
+                2,
+                3,
+                5
+            ],
+            "legIntPurposeIds": [],
+            "featureIds": [
+                1,
+                2,
+                3
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This PR includes two important fixes for vendors ranges generation.

1) The ranges generation algorithm assumes that the vendors list is sorted by ID which is not the case practically. This PR sorts the list when it is added (`setGlobalVendorList`).

2) The GVL has missing IDs where you can have vendor 1 and vendor 3 defined but not vendor 2. This happens as IDs get allocated but vendors do not get added immediately. It could also happen if an ID is removed from the list.
Previously, if you generated ranges with allowed vendors `[1, 3]` in that case, the algorithm would usually generate the range `[1, 3]` and assume that vendor 2 also has consent which is incorrect.
The fix ensures that only defined vendors are included in ranges and would now generate two separate "ranges" (1 and 3).