### PR TITLE
Removed unnecessary parseInt of integer value

### DIFF
--- a/src/utils/bits.js
+++ b/src/utils/bits.js
@@ -28,7 +28,7 @@ function encodeIntToBits(number, numBits) {
   let bitString = '';
 
   if (typeof number === 'number' && !isNaN(number)) {
-    bitString = parseInt(number, 10).toString(2);
+    bitString = number.toString(2);
   }
 
   // Pad the string if not filling all bits


### PR DESCRIPTION
Number is already known to be an integer here, the parseInt doesn't do anything.