### PR TITLE
Remove all array destructors and drop array from babel dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,6 @@
     ],
     "plugins": [
       "transform-object-rest-spread",
-      "@59naga/babel-plugin-transform-array-from",
       "transform-es2015-arrow-functions",
       "transform-es2015-classes",
       "transform-es2015-destructuring",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "@59naga/babel-plugin-transform-array-from": "0.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",

--- a/src/encode.js
+++ b/src/encode.js
@@ -26,14 +26,15 @@ function encodeVendorIdsToBits(maxVendorId, allowedVendorIds = []) {
  * @param {*} allowedPurposeIds List of purpose IDs that the user has given consent to
  */
 function encodePurposeIdsToBits(purposes, allowedPurposeIds = new Set()) {
-  const maxPurposeId = Math.max(
-    0,
-    ...purposes.map(({ id }) => id),
-    ...Array.from(allowedPurposeIds),
-  );
+  let maxPurposeId = 0;
+  for (let i = 0; i < purposes.length; i += 1) {
+    maxPurposeId = Math.max(maxPurposeId, purposes[i].id);
+  }
+  for (let i = 0; i < allowedPurposeIds.length; i += 1) {
+    maxPurposeId = Math.max(maxPurposeId, allowedPurposeIds[i]);
+  }
 
   let purposeString = '';
-
   for (let id = 1; id <= maxPurposeId; id += 1) {
     purposeString += (allowedPurposeIds.indexOf(id) !== -1 ? '1' : '0');
   }
@@ -49,10 +50,12 @@ function encodePurposeIdsToBits(purposes, allowedPurposeIds = new Set()) {
  */
 function convertVendorsToRanges(vendors, allowedVendorIds) {
   let range = [];
+  const ranges = [];
 
   const idsInList = vendors.map(vendor => vendor.id);
 
-  return vendors.reduce((acc, { id }, index) => {
+  for (let index = 0; index < vendors.length; index += 1) {
+    const { id } = vendors[index];
     if (allowedVendorIds.indexOf(id) !== -1) {
       range.push(id);
     }
@@ -71,15 +74,15 @@ function convertVendorsToRanges(vendors, allowedVendorIds) {
 
       range = [];
 
-      return [...acc, {
+      ranges.push({
         isRange: typeof endVendorId === 'number',
         startVendorId,
         endVendorId,
-      }];
+      });
     }
+  }
 
-    return acc;
-  }, []);
+  return ranges;
 }
 
 /**


### PR DESCRIPTION
This PR drops all uses of the Array destructor, and then the need for the array-from babel package, which was adding ~3.2kb to 6 final dist files. That's ~19.2kb for bundles which are meant to be used on the front-end, which I guess is the whole point of this project.

Personally, I'm also a fan of the for loop. E.g.: it's a lot more performant to use that instead of an array destruction with a `.map` when the desired result is a max value.

A drawback of this PR is that it basically makes it mandatory to not use the Array destructor in the future.