### PR TITLE
cachedString is not shared between instance

### DIFF
--- a/src/consent-string.js
+++ b/src/consent-string.js
@@ -5,10 +5,10 @@ const { vendorVersionMap } = require('./utils/definitions');
  * Regular expression for validating
  */
 const consentLanguageRegexp = /^[a-z]{2}$/;
-let cachedString;
 
 class ConsentString {
   constructor(baseString = null) {
+    this.cachedString = baseString;
     this.maxVendorId = 0;
     this.created = new Date();
     this.lastUpdated = new Date();
@@ -24,7 +24,6 @@ class ConsentString {
 
     // Decode the base string
     if (baseString) {
-      cachedString = baseString;
       Object.assign(this, decodeConsentString(baseString));
     }
   }
@@ -36,8 +35,8 @@ class ConsentString {
      * check for cached string that was passed in.  This avoids having to
      * decode the consent string and even to have a vendorlist
      */
-    if (cachedString && !updateDate) {
-      retr = cachedString;
+    if (this.cachedString && !updateDate) {
+      retr = this.cachedString;
     } else {
       if (!this.vendorList) {
         throw new Error('ConsentString - A vendor list is required to encode a consent string');
@@ -61,7 +60,7 @@ class ConsentString {
         vendorListVersion: this.vendorListVersion,
       });
 
-      cachedString = retr;
+      this.cachedString = retr;
     }
     return retr;
   }
@@ -69,7 +68,7 @@ class ConsentString {
     return this.lastUpdated;
   }
   setLastUpdated(date = null) {
-    cachedString = '';
+    this.cachedString = null;
     if (date) {
       this.lastUpdated = new Date(date);
     } else {
@@ -80,7 +79,7 @@ class ConsentString {
     return this.created;
   }
   setCreated(date = null) {
-    cachedString = '';
+    this.cachedString = null;
     if (date) {
       this.created = new Date(date);
     } else {
@@ -143,7 +142,7 @@ class ConsentString {
 
     // does a vendorList already exist and is it a different version
     if (!this.vendorList || this.vendorListVersion !== vendorList.vendorListVersion) {
-      cachedString = '';
+      this.cachedString = null;
       // Cloning the GVL
       // It's important as we might transform it and don't want to modify objects that we do not own
       this.vendorList = {
@@ -166,7 +165,7 @@ class ConsentString {
   }
   setCmpId(id) {
     if (id !== this.cmpId) {
-      cachedString = '';
+      this.cachedString = null;
       this.cmpId = id;
     }
   }
@@ -175,7 +174,7 @@ class ConsentString {
   }
   setCmpVersion(version) {
     if (version !== this.cmpVersion) {
-      cachedString = '';
+      this.cachedString = null;
       this.cmpVersion = version;
     }
   }
@@ -184,7 +183,7 @@ class ConsentString {
   }
   setConsentScreen(screenId) {
     if (screenId !== this.consentScreen) {
-      cachedString = '';
+      this.cachedString = null;
       this.consentScreen = screenId;
     }
   }
@@ -197,7 +196,7 @@ class ConsentString {
     }
 
     if (language !== this.consentLanguage) {
-      cachedString = '';
+      this.cachedString = null;
       this.consentLanguage = language;
     }
   }
@@ -205,7 +204,7 @@ class ConsentString {
     return this.consentLanguage;
   }
   setPurposesAllowed(purposeIds) {
-    cachedString = '';
+    this.cachedString = null;
     this.allowedPurposeIds = purposeIds;
   }
   getPurposesAllowed() {
@@ -214,7 +213,7 @@ class ConsentString {
   setPurposeAllowed(purposeId, value) {
     const purposeIndex = this.allowedPurposeIds.indexOf(purposeId);
 
-    cachedString = '';
+    this.cachedString = null;
 
     if (value === true) {
       if (purposeIndex === -1) {
@@ -230,7 +229,7 @@ class ConsentString {
     return this.allowedPurposeIds.indexOf(purposeId) !== -1;
   }
   setVendorsAllowed(vendorIds) {
-    cachedString = '';
+    this.cachedString = null;
     this.allowedVendorIds = vendorIds;
   }
   getVendorsAllowed() {
@@ -239,7 +238,7 @@ class ConsentString {
   setVendorAllowed(vendorId, value) {
     const vendorIndex = this.allowedVendorIds.indexOf(vendorId);
 
-    cachedString = '';
+    this.cachedString = null;
     if (value === true) {
       if (vendorIndex === -1) {
         this.allowedVendorIds.push(vendorId);

--- a/test/consent-string.test.js
+++ b/test/consent-string.test.js
@@ -196,4 +196,21 @@ describe('ConsentString', function () {
       ]);
     });
   });
+
+  it('two object do not share the same cache', function () {
+    const consentString1 = new ConsentString();
+    consentString1.setGlobalVendorList(vendorList);
+    Object.assign(consentString1, consentData);
+    consentString1.setCreated(new Date('2018-07-10 PDT'));
+
+    const consentString2 = new ConsentString();
+    consentString2.setGlobalVendorList(vendorList);
+    Object.assign(consentString2, consentData);
+    consentString1.setCreated(new Date('2018-07-12 PDT'));
+
+    expect(consentString1.getConsentString(false))
+      .to
+      .not
+      .equal(consentString2.getConsentString(false));
+  });
 });


### PR DESCRIPTION
Sharing cachedString lead to have the same getConsentString
on separate instance for distinct data where we do not want to
update the updatedAt field