### PR TITLE
Fix missing TS method

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,7 @@ export class ConsentString {
   private allowedVendorIds: number[];
 
   public getConsentString(updateDate?:boolean): string;
+  public getLastUpdated(): Date;
   public getVersion(): number;
   public getVendorListVersion(): number;
   public setGlobalVendorList(vendorList: VendorList): void;


### PR DESCRIPTION
# Issue
On TypeScript, we are not able to use the method `getLastUpdated` neither the field `lastUpdated` (private). We are not able to know if our Consent-string has expired or not.

# Fix
Simply add the method signature to the `index.d.ts` file.